### PR TITLE
feat: persist truetime info to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ You can read more about the use case in our [blog post](https://tech.instacart.c
 
 It's pretty simple actually. We make a request to an NTP server that gives us the actual time. We then establish the delta between device uptime and uptime at the time of the network response. Each time "now" is requested subsequently, we account for that offset and return a corrected `Date` object.
 
+Also, once we have this information it's valid until the next time you boot your device. This means if you enable the disk caching feature, after a signle successfull SNTP request you can use the information on disk directly without ever making another network request. This applies even across application kills which can happen frequently if your users have a memory starved device.
+
 # Installation
 
 We use [Jitpack](https://jitpack.io) to host the library.
@@ -88,7 +90,7 @@ TrueTimeRx.now(); // return a Date object with the "true" time.
 
 ## Notes/tips:
 
-* You want to `initialize` only once per device restart. This means as long as your device is not restarted, TrueTime needs to be initialized only once.
+* Each `initialize` call makes an SNTP network request. TrueTime needs to be `initialize`d only once ever, per device boot. Use TrueTime's `withSharedPreferences` option to make use of this feature and avoid repeated network request calls.
 * Preferable use dependency injection (like [Dagger](http://square.github.io/dagger/)) and create a TrueTime @Singleton object
 * TrueTime was built to be accurate "enough", hence the use of [SNTP](https://en.wikipedia.org/wiki/Network_Time_Protocol#SNTP). If you need exact millisecond accuracy then you probably want [NTP](https://www.meinbergglobal.com/english/faq/faq_37.htm) (i.e. SNTP + statistical analysis to ensure the reference time is exactly correct). TrueTime provides the building blocks for this. We welcome PRs if you think you can do this with TrueTime(Rx) pretty easily :).
 * TrueTime is also [available for iOS/Swift](https://github.com/instacart/truetime.swift)

--- a/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
+++ b/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
@@ -47,7 +47,7 @@ public class Sample2Activity
                                               "3.north-america.pool.ntp.org",
                                               "0.us.pool.ntp.org",
                                               "1.us.pool.ntp.org");
-        //TrueTimeRx.clearCachedInfo(prefs);
+        //TrueTimeRx.clearCachedInfo(this);
 
         TrueTimeRx.build()
               .withConnectionTimeout(31_428)

--- a/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
+++ b/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
@@ -1,6 +1,5 @@
 package com.instacart.library.sample;
 
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -48,13 +47,12 @@ public class Sample2Activity
                                               "3.north-america.pool.ntp.org",
                                               "0.us.pool.ntp.org",
                                               "1.us.pool.ntp.org");
-        SharedPreferences prefs = getSharedPreferences("test", MODE_PRIVATE);
         //TrueTimeRx.clearCachedInfo(prefs);
 
         TrueTimeRx.build()
               .withConnectionTimeout(31_428)
               .withRetryCount(100)
-              .withSharedPreferences(prefs)
+              .withSharedPreferences(this)
               .initialize(ntpHosts)
               .subscribeOn(Schedulers.io())
               .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
+++ b/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
@@ -1,5 +1,6 @@
 package com.instacart.library.sample;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -47,9 +48,13 @@ public class Sample2Activity
                                               "3.north-america.pool.ntp.org",
                                               "0.us.pool.ntp.org",
                                               "1.us.pool.ntp.org");
+        SharedPreferences prefs = getSharedPreferences("test", MODE_PRIVATE);
+        //TrueTimeRx.clearCachedInfo(prefs);
+
         TrueTimeRx.build()
               .withConnectionTimeout(31_428)
               .withRetryCount(100)
+              .withSharedPreferences(prefs)
               .initialize(ntpHosts)
               .subscribeOn(Schedulers.io())
               .observeOn(AndroidSchedulers.mainThread())
@@ -95,5 +100,4 @@ public class Sample2Activity
         format.setTimeZone(timeZone);
         return format.format(date);
     }
-
 }

--- a/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
+++ b/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
@@ -30,6 +30,7 @@ public class Sample2Activity
     @Bind(R.id.tt_btn_refresh) Button refreshBtn;
     @Bind(R.id.tt_time_gmt) TextView timeGMT;
     @Bind(R.id.tt_time_pst) TextView timePST;
+    @Bind(R.id.tt_time_device) TextView timeDeviceTime;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -68,15 +69,25 @@ public class Sample2Activity
                       refreshBtn.setEnabled(true);
                   }
               });
-
     }
 
     @OnClick(R.id.tt_btn_refresh)
     public void onBtnRefresh() {
-        Log.d("kg", String.format(" [now: %d] [new Date: %d]", TrueTime.now().getTime(), new Date().getTime()));
-        timePST.setText(_formatDate(TrueTime.now(), "yyyy-MM-dd HH:mm:ss", TimeZone.getTimeZone("GMT-07:00")) +
-                        " [PST]");
-        timeGMT.setText(_formatDate(TrueTime.now(), "yyyy-MM-dd HH:mm:ss", TimeZone.getTimeZone("GMT")) + " [GMT]");
+        Date trueTime = TrueTime.now();
+        Date deviceTime = new Date();
+
+        Log.d("kg",
+              String.format(" [trueTime: %d] [devicetime: %d] [drift_sec: %f]",
+                            trueTime.getTime(),
+                            deviceTime.getTime(),
+                            (trueTime.getTime() - deviceTime.getTime()) / 1000F));
+
+        timeGMT.setText(getString(R.string.tt_time_gmt,
+                                  _formatDate(trueTime, "yyyy-MM-dd HH:mm:ss", TimeZone.getTimeZone("GMT"))));
+        timePST.setText(getString(R.string.tt_time_pst,
+                                  _formatDate(trueTime, "yyyy-MM-dd HH:mm:ss", TimeZone.getTimeZone("GMT-07:00"))));
+        timeDeviceTime.setText(getString(R.string.tt_time_device,
+                                         _formatDate(deviceTime, "yyyy-MM-dd HH:mm:ss", TimeZone.getTimeZone("GMT-07:00"))));
     }
 
     private String _formatDate(Date date, String pattern, TimeZone timeZone) {

--- a/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
+++ b/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
@@ -5,6 +5,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 import butterknife.Bind;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
@@ -76,6 +77,11 @@ public class Sample2Activity
 
     @OnClick(R.id.tt_btn_refresh)
     public void onBtnRefresh() {
+        if (!TrueTimeRx.isInitialized()) {
+            Toast.makeText(this, "Sorry TrueTime not yet initialized.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
         Date trueTime = TrueTime.now();
         Date deviceTime = new Date();
 

--- a/app/src/main/java/com/instacart/library/sample/SampleActivity.java
+++ b/app/src/main/java/com/instacart/library/sample/SampleActivity.java
@@ -10,6 +10,7 @@ import butterknife.Bind;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import com.instacart.library.truetime.TrueTime;
+import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -18,6 +19,8 @@ import java.util.TimeZone;
 
 public class SampleActivity
       extends AppCompatActivity {
+
+    private static final String TAG = SampleActivity.class.getSimpleName();
 
     @Bind(R.id.tt_time_gmt) TextView timeGMT;
     @Bind(R.id.tt_time_pst) TextView timePST;
@@ -56,7 +59,12 @@ public class SampleActivity
           extends AsyncTask<Void, Void, Void> {
 
         protected Void doInBackground(Void... params) {
-            TrueTime.build().withNtpHost("0.north-america.pool.ntp.org").withConnectionTimeout(3_1428).initialize();
+            try {
+                TrueTime.build().withNtpHost("0.north-america.pool.ntp.org").withConnectionTimeout(3_1428).initialize();
+            } catch (IOException e) {
+                e.printStackTrace();
+                Log.e(TAG, "Exception when trying to get TrueTime", e);
+            }
             return null;
         }
     }

--- a/app/src/main/java/com/instacart/library/sample/SampleActivity.java
+++ b/app/src/main/java/com/instacart/library/sample/SampleActivity.java
@@ -24,6 +24,7 @@ public class SampleActivity
 
     @Bind(R.id.tt_time_gmt) TextView timeGMT;
     @Bind(R.id.tt_time_pst) TextView timePST;
+    @Bind(R.id.tt_time_device) TextView timeDeviceTime;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -38,14 +39,23 @@ public class SampleActivity
     @OnClick(R.id.tt_btn_refresh)
     public void onBtnRefresh() {
         if (!TrueTime.isInitialized()) {
-            Toast.makeText(this, "Sorry TrueTime not yet initialized", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, "Sorry TrueTime not yet initialized. Trying again.", Toast.LENGTH_SHORT).show();
+            new InitTrueTimeAsyncTask().execute();
             return;
         }
 
-        Log.d("kg", String.format(" [now: %d] [new Date: %d]", TrueTime.now().getTime(), new Date().getTime()));
-        timePST.setText(_formatDate(TrueTime.now(), "yyyy-MM-dd HH:mm:ss", TimeZone.getTimeZone("GMT-07:00")) +
-                        " [PST]");
-        timeGMT.setText(_formatDate(TrueTime.now(), "yyyy-MM-dd HH:mm:ss", TimeZone.getTimeZone("GMT")) + " [GMT]");
+        Date trueTime = TrueTime.now();
+        Date deviceTime = new Date();
+
+        timeGMT.setText(getString(R.string.tt_time_gmt,
+                                  _formatDate(trueTime, "yyyy-MM-dd HH:mm:ss", TimeZone.getTimeZone("GMT"))));
+        timePST.setText(getString(R.string.tt_time_pst,
+                                  _formatDate(trueTime, "yyyy-MM-dd HH:mm:ss", TimeZone.getTimeZone("GMT-07:00"))));
+        timeDeviceTime.setText(getString(R.string.tt_time_device,
+                                         _formatDate(deviceTime, "yyyy-MM-dd HH:mm:ss", TimeZone.getTimeZone("GMT-07:00"))));
+
+
+
     }
 
     private String _formatDate(Date date, String pattern, TimeZone timeZone) {
@@ -60,7 +70,11 @@ public class SampleActivity
 
         protected Void doInBackground(Void... params) {
             try {
-                TrueTime.build().withNtpHost("0.north-america.pool.ntp.org").withConnectionTimeout(3_1428).initialize();
+                TrueTime.build()
+                      //.withSharedPreferences(SampleActivity.this)
+                      .withNtpHost("0.north-america.pool.ntp.org")
+                      .withConnectionTimeout(3_1428)
+                      .initialize();
             } catch (IOException e) {
                 e.printStackTrace();
                 Log.e(TAG, "Exception when trying to get TrueTime", e);

--- a/app/src/main/res/layout/activity_sample.xml
+++ b/app/src/main/res/layout/activity_sample.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/activity_main"
@@ -8,52 +9,69 @@
     tools:context="com.instacart.library.sample.SampleActivity">
 
     <TextView
-        android:id="@+id/tt_time_gmt"
-
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-
-        android:text="GMT time goes here"
-        android:textSize="22dp"
-
-        app:layout_constraintLeft_toLeftOf="@+id/activity_main"
-        tools:layout_constraintLeft_creator="1"
-        app:layout_constraintTop_toTopOf="@+id/activity_main"
-        tools:layout_constraintTop_creator="1"
-        app:layout_constraintRight_toRightOf="@+id/activity_main"
-        tools:layout_constraintRight_creator="1"
-        app:layout_constraintBottom_toBottomOf="@+id/activity_main"
-        tools:layout_constraintBottom_creator="1"
-        app:layout_constraintVertical_bias="0.41" />
-
-    <TextView
         android:id="@+id/tt_time_pst"
 
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
 
-        android:text="PST time goes here"
-        android:textSize="22dp"
+        android:text="GMT time goes here"
+        android:textSize="20dp"
 
-        app:layout_constraintRight_toRightOf="@+id/tt_time_gmt"
+        app:layout_constraintBottom_toBottomOf="@+id/activity_main"
+        app:layout_constraintLeft_toLeftOf="@+id/activity_main"
+        app:layout_constraintRight_toRightOf="@+id/activity_main"
+        app:layout_constraintTop_toTopOf="@+id/activity_main"
+        tools:layout_constraintBottom_creator="1"
+        tools:layout_constraintLeft_creator="1"
         tools:layout_constraintRight_creator="1"
-        app:layout_constraintBottom_toTopOf="@+id/tt_btn_refresh"
-        android:layout_marginBottom="14dp"
-        tools:layout_constraintBottom_creator="1" />
+        tools:layout_constraintTop_creator="1"/>
 
+    <TextView
+        android:id="@+id/tt_time_gmt"
+
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+
+        android:layout_marginTop="16dp"
+        android:text="PST time goes here"
+
+        android:textSize="20dp"
+        app:layout_constraintRight_toRightOf="@+id/tt_time_pst"
+        app:layout_constraintTop_toBottomOf="@+id/tt_time_pst"
+        tools:layout_constraintRight_creator="1"
+        tools:layout_constraintTop_creator="1"/>
+
+    <TextView
+        android:id="@+id/tt_time_device"
+
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+
+        android:text="Device time goes here"
+        android:textSize="20dp"
+
+        app:layout_constraintBottom_toTopOf="@+id/tt_time_pst"
+        app:layout_constraintHorizontal_bias="0.47"
+        app:layout_constraintLeft_toLeftOf="@+id/activity_main"
+        app:layout_constraintRight_toRightOf="@+id/activity_main"
+        tools:layout_constraintBottom_creator="1"
+        tools:layout_constraintLeft_creator="1"
+        tools:layout_constraintRight_creator="1"/>
 
     <Button
         android:id="@+id/tt_btn_refresh"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
 
+        android:layout_marginTop="16dp"
         android:text="Get Time NOW"
         app:layout_constraintLeft_toLeftOf="@+id/activity_main"
-        tools:layout_constraintLeft_creator="1"
-        app:layout_constraintTop_toBottomOf="@+id/tt_time_gmt"
-        android:layout_marginTop="56dp"
-        tools:layout_constraintTop_creator="1"
         app:layout_constraintRight_toRightOf="@+id/activity_main"
-        tools:layout_constraintRight_creator="1" />
+        app:layout_constraintTop_toBottomOf="@+id/tt_time_gmt"
+        tools:layout_constraintLeft_creator="1"
+        tools:layout_constraintRight_creator="1"
+        tools:layout_constraintTop_creator="1"/>
+
 
 </android.support.constraint.ConstraintLayout>

--- a/library-extension-rx/src/main/java/com/instacart/library/truetime/extensionrx/TrueTimeRx.java
+++ b/library-extension-rx/src/main/java/com/instacart/library/truetime/extensionrx/TrueTimeRx.java
@@ -51,9 +51,9 @@ public class TrueTimeRx
                                 @Override
                                 public Observable<Date> call(String ntpHost) {
                                     try {
+                                        Log.i(TAG, "---- Querying host : " + ntpHost);
 
                                         SntpClient sntpClient = new SntpClient();
-                                        Log.i(TAG, "---- Querying host : " + ntpHost);
                                         sntpClient.requestTime(ntpHost, udpSocketTimeoutInMillis);
                                         setSntpClient(sntpClient);
 

--- a/library-extension-rx/src/main/java/com/instacart/library/truetime/extensionrx/TrueTimeRx.java
+++ b/library-extension-rx/src/main/java/com/instacart/library/truetime/extensionrx/TrueTimeRx.java
@@ -1,6 +1,6 @@
 package com.instacart.library.truetime.extensionrx;
 
-import android.content.SharedPreferences;
+import android.content.Context;
 import com.instacart.library.truetime.TrueTime;
 import java.io.IOException;
 import java.util.Date;
@@ -21,8 +21,8 @@ public class TrueTimeRx
         return RX_INSTANCE;
     }
 
-    public TrueTimeRx withSharedPreferences(SharedPreferences preferences) {
-        super.withSharedPreferences(preferences);
+    public TrueTimeRx withSharedPreferences(Context context) {
+        super.withSharedPreferences(context);
         return this;
     }
 

--- a/library-extension-rx/src/main/java/com/instacart/library/truetime/extensionrx/TrueTimeRx.java
+++ b/library-extension-rx/src/main/java/com/instacart/library/truetime/extensionrx/TrueTimeRx.java
@@ -13,7 +13,6 @@ import rx.schedulers.Schedulers;
 public class TrueTimeRx
       extends TrueTime {
 
-    private static final String TAG = TrueTimeRx.class.getSimpleName();
     private static final TrueTimeRx RX_INSTANCE = new TrueTimeRx();
 
     private int _retryCount = 50;

--- a/library-extension-rx/src/main/java/com/instacart/library/truetime/extensionrx/TrueTimeRx.java
+++ b/library-extension-rx/src/main/java/com/instacart/library/truetime/extensionrx/TrueTimeRx.java
@@ -14,27 +14,27 @@ public class TrueTimeRx
       extends TrueTime {
 
     private static final String TAG = TrueTimeRx.class.getSimpleName();
-    private static final TrueTime INSTANCE = new TrueTimeRx();
+    private static final TrueTimeRx RX_INSTANCE = new TrueTimeRx();
 
     private int _retryCount = 50;
 
     public static TrueTimeRx build() {
-        return (TrueTimeRx) INSTANCE;
+        return RX_INSTANCE;
     }
 
     public TrueTimeRx withSharedPreferences(SharedPreferences preferences) {
         super.withSharedPreferences(preferences);
-        return (TrueTimeRx) INSTANCE;
+        return this;
     }
 
     public TrueTimeRx withConnectionTimeout(int timeout) {
         super.withConnectionTimeout(timeout);
-        return (TrueTimeRx) INSTANCE;
+        return this;
     }
 
     public TrueTimeRx withRetryCount(int retryCount) {
         _retryCount = retryCount;
-        return (TrueTimeRx) INSTANCE;
+        return this;
     }
 
     /**
@@ -70,12 +70,10 @@ public class TrueTimeRx
                                     throwable.printStackTrace();
                                     return null;
                                 }
-                            })
-                            .take(1)
-                            .doOnNext(new Action1<Date>() {
+                            }).take(1).doOnNext(new Action1<Date>() {
                                 @Override
                                 public void call(Date date) {
-                                    cacheTrueTimeInfo(sharedPreferences);
+                                    cacheTrueTimeInfo();
                                 }
                             });
                   }

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -7,6 +7,16 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
-    <application android:label="@string/app_name"></application>
+    <!--Detect boot to invalidate TrueTime-->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+
+    <application android:label="@string/app_name">
+        <!-- Start the Service if applicable on boot -->
+        <receiver android:name="BootupCompletedBroadcastReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+            </intent-filter>
+        </receiver>
+    </application>
 
 </manifest>

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
 
     <application android:label="@string/app_name">
         <!-- Start the Service if applicable on boot -->
-        <receiver android:name="BootupCompletedBroadcastReceiver">
+        <receiver android:name=".BootCompletedBroadcastReceiver">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
             </intent-filter>

--- a/library/src/main/java/com/instacart/library/truetime/BootCompletedBroadcastReceiver.java
+++ b/library/src/main/java/com/instacart/library/truetime/BootCompletedBroadcastReceiver.java
@@ -5,10 +5,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
-public class BootupCompletedBroadcastReceiver
+public class BootCompletedBroadcastReceiver
       extends BroadcastReceiver {
 
-    private static final String TAG = BootupCompletedBroadcastReceiver.class.getSimpleName();
+    private static final String TAG = BootCompletedBroadcastReceiver.class.getSimpleName();
 
     @Override
     public void onReceive(Context context, Intent intent) {

--- a/library/src/main/java/com/instacart/library/truetime/BootupCompletedBroadcastReceiver.java
+++ b/library/src/main/java/com/instacart/library/truetime/BootupCompletedBroadcastReceiver.java
@@ -1,0 +1,18 @@
+package com.instacart.library.truetime;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+public class BootupCompletedBroadcastReceiver
+      extends BroadcastReceiver {
+
+    private static final String TAG = BootupCompletedBroadcastReceiver.class.getSimpleName();
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Log.i(TAG, "---- clearing TrueTime disk cache as we've detected a boot");
+        TrueTime.clearCachedInfo(context);
+    }
+}

--- a/library/src/main/java/com/instacart/library/truetime/DiskCacheClient.java
+++ b/library/src/main/java/com/instacart/library/truetime/DiskCacheClient.java
@@ -68,7 +68,7 @@ public class DiskCacheClient {
 
         boolean bootTimeSame = currentBootTime == cachedBootTime;
 
-        Log.i(TAG, "boot time changed " + !bootTimeSame);
+        Log.i(TAG, "---- boot time changed " + !bootTimeSame);
 
         return bootTimeSame;
     }

--- a/library/src/main/java/com/instacart/library/truetime/DiskCacheClient.java
+++ b/library/src/main/java/com/instacart/library/truetime/DiskCacheClient.java
@@ -1,0 +1,101 @@
+package com.instacart.library.truetime;
+
+import android.content.SharedPreferences;
+import android.os.SystemClock;
+import android.util.Log;
+
+public class DiskCacheClient {
+
+    static final String KEY_CACHED_BOOT_TIME = "com.instacart.library.truetime.cached_boot_time";
+    static final String KEY_CACHED_DEVICE_UPTIME = "com.instacart.library.truetime.cached_device_uptime";
+    static final String KEY_CACHED_SNTP_TIME = "com.instacart.library.truetime.cached_sntp_time";
+
+    private static final String TAG = DiskCacheClient.class.getSimpleName();
+
+    private SharedPreferences _sharedPreferences = null;
+
+    public void setSource(SharedPreferences sharedPreferences) {
+        _sharedPreferences = sharedPreferences;
+    }
+
+    void clearCachedInfo(SharedPreferences sharedPreferences) {
+        if (sharedPreferences == null) {
+            return;
+        }
+
+        sharedPreferences.edit().remove(KEY_CACHED_BOOT_TIME).apply();
+        sharedPreferences.edit().remove(KEY_CACHED_DEVICE_UPTIME).apply();
+        sharedPreferences.edit().remove(KEY_CACHED_SNTP_TIME).apply();
+    }
+
+    void cacheTrueTimeInfo(SntpClient sntpClient) {
+        if (sharedPreferencesUnavailable()) {
+            return;
+        }
+
+        long cachedSntpTime = sntpClient.getCachedSntpTime();
+        long cachedDeviceUptime = sntpClient.getCachedDeviceUptime();
+        long bootTime = cachedSntpTime - cachedDeviceUptime;
+
+        Log.d(TAG,
+              String.format("Caching true time info to disk sntp [%s] device [%s] boot [%s]",
+                            cachedSntpTime,
+                            cachedDeviceUptime,
+                            bootTime));
+
+        _sharedPreferences.edit().putLong(DiskCacheClient.KEY_CACHED_BOOT_TIME, bootTime).apply();
+        _sharedPreferences.edit().putLong(DiskCacheClient.KEY_CACHED_DEVICE_UPTIME, cachedDeviceUptime).apply();
+        _sharedPreferences.edit().putLong(DiskCacheClient.KEY_CACHED_SNTP_TIME, cachedSntpTime).apply();
+
+    }
+
+    boolean isTrueTimeCachedFromAPreviousBoot() {
+        if (sharedPreferencesUnavailable()) {
+            return false;
+        }
+
+        long cachedBootTime = _sharedPreferences.getLong(DiskCacheClient.KEY_CACHED_BOOT_TIME, 0L);
+        if (cachedBootTime == 0) {
+            return false;
+        }
+
+        // has boot time changed
+        long cachedSntpTime = getCachedSntpTime();
+        long cachedDeviceUptime = getCachedDeviceUptime();
+        long currentDeviceUptime = SystemClock.elapsedRealtime();
+        long nowAccordingToCachedTrueTime = cachedSntpTime + (currentDeviceUptime - cachedDeviceUptime);
+        long currentBootTime = nowAccordingToCachedTrueTime - currentDeviceUptime;
+
+        boolean bootTimeSame = currentBootTime == cachedBootTime;
+
+        Log.i(TAG, "boot time changed " + !bootTimeSame);
+
+        return bootTimeSame;
+    }
+
+    long getCachedDeviceUptime() {
+        if (sharedPreferencesUnavailable()) {
+            return 0L;
+        }
+
+        return _sharedPreferences.getLong(DiskCacheClient.KEY_CACHED_DEVICE_UPTIME, 0L);
+    }
+
+    long getCachedSntpTime() {
+        if (sharedPreferencesUnavailable()) {
+            return 0L;
+        }
+
+        return _sharedPreferences.getLong(DiskCacheClient.KEY_CACHED_SNTP_TIME, 0L);
+    }
+
+    // -----------------------------------------------------------------------------------
+
+    private boolean sharedPreferencesUnavailable() {
+        if (_sharedPreferences == null) {
+            Log.w(TAG, "Cannot use disk caching strategy for TrueTime. SharedPreferences unavailable");
+            return true;
+        }
+        return false;
+    }
+}

--- a/library/src/main/java/com/instacart/library/truetime/SntpClient.java
+++ b/library/src/main/java/com/instacart/library/truetime/SntpClient.java
@@ -48,6 +48,7 @@ public class SntpClient {
 
     private long _cachedDeviceUptime;
     private long _cachedSntpTime;
+    private boolean _sntpInitialized = false;
 
     /**
      * Sends an NTP request to the given host and processes the response.
@@ -55,7 +56,7 @@ public class SntpClient {
      * @param ntpHost         host name of the server.
      * @param timeoutInMillis network timeout in milliseconds.
      */
-    public void requestTime(String ntpHost, int timeoutInMillis) throws IOException {
+    void requestTime(String ntpHost, int timeoutInMillis) throws IOException {
 
         DatagramSocket socket = null;
 
@@ -135,6 +136,7 @@ public class SntpClient {
             }
 
             Log.i(TAG, "---- Received successful response from " + ntpHost);
+            _sntpInitialized = true;
 
             // -----------------------------------------------------------------------------------
             // θ
@@ -143,6 +145,12 @@ public class SntpClient {
             _cachedSntpTime = responseTime + clockOffset;
             _cachedDeviceUptime = responseTicks;
 
+        } catch (Exception e) {
+            //hacking
+            Log.d(TAG, "---- SNTP request failed for " + ntpHost);
+            Log.e(TAG, "SNTP request failed", new Throwable(e));
+            _sntpInitialized = false;
+            throw e;
         } finally {
             if (socket != null) {
                 socket.close();
@@ -162,6 +170,10 @@ public class SntpClient {
      */
     long getCachedDeviceUptime() {
         return _cachedDeviceUptime;
+    }
+
+    boolean wasInitialized() {
+        return _sntpInitialized;
     }
 
     // -----------------------------------------------------------------------------------

--- a/library/src/main/java/com/instacart/library/truetime/SntpClient.java
+++ b/library/src/main/java/com/instacart/library/truetime/SntpClient.java
@@ -135,8 +135,8 @@ public class SntpClient {
                 throw new InvalidNtpServerResponseException("Server response delay too large for comfort " + delay);
             }
 
-            Log.i(TAG, "---- Received successful response from " + ntpHost);
             _sntpInitialized = true;
+            Log.i(TAG, "---- SNTP successful response from " + ntpHost);
 
             // -----------------------------------------------------------------------------------
             // θ

--- a/library/src/main/java/com/instacart/library/truetime/SntpClient.java
+++ b/library/src/main/java/com/instacart/library/truetime/SntpClient.java
@@ -146,10 +146,7 @@ public class SntpClient {
             _cachedDeviceUptime = responseTicks;
 
         } catch (Exception e) {
-            //hacking
             Log.d(TAG, "---- SNTP request failed for " + ntpHost);
-            Log.e(TAG, "SNTP request failed", new Throwable(e));
-            _sntpInitialized = false;
             throw e;
         } finally {
             if (socket != null) {

--- a/library/src/main/java/com/instacart/library/truetime/TrueTime.java
+++ b/library/src/main/java/com/instacart/library/truetime/TrueTime.java
@@ -1,15 +1,22 @@
 package com.instacart.library.truetime;
 
+import android.content.SharedPreferences;
 import android.os.SystemClock;
 import android.util.Log;
 import java.io.IOException;
 import java.util.Date;
+import java.util.Locale;
 
 public class TrueTime {
 
     private static final String TAG = TrueTime.class.getSimpleName();
+
+    private static final String KEY_CACHED_BOOT_TIME = "com.instacart.library.truetime.cached_boot_time";
+    private static final String KEY_CACHED_DEVICE_UPTIME = "com.instacart.library.truetime.cached_device_uptime";
+    private static final String KEY_CACHED_SNTP_TIME = "com.instacart.library.truetime.cached_sntp_time";
     private static final TrueTime INSTANCE = new TrueTime();
 
+    protected SharedPreferences sharedPreferences = null;
     protected int udpSocketTimeoutInMillis = 30_000;
 
     private String _ntpHost = "1.us.pool.ntp.org";
@@ -28,20 +35,56 @@ public class TrueTime {
             throw new IllegalStateException("You need to call init() on TrueTime at least once.");
         }
 
-        long now = INSTANCE._sntpClient.getCachedSntpTime()//
-                   + SystemClock.elapsedRealtime() -
-                   INSTANCE._sntpClient.getCachedDeviceUptime(); // elapsed deviceUptime from calc.
+        long cachedSntpTime = _getCachedSntpTime();
+        long cachedDeviceUptime = _getCachedDeviceUptime();
+        long deviceUptime = SystemClock.elapsedRealtime();
+
+        long now = cachedSntpTime + (deviceUptime - cachedDeviceUptime);
+
+        long nowSntp = 0L;
+
+        if (INSTANCE._sntpClient != null) {
+            nowSntp = INSTANCE._sntpClient.getCachedSntpTime() + deviceUptime -
+                      INSTANCE._sntpClient.getCachedDeviceUptime();
+        }
+
+        long nowDisk = INSTANCE.sharedPreferences.getLong(KEY_CACHED_SNTP_TIME, 0L) + deviceUptime -
+                       INSTANCE.sharedPreferences.getLong(KEY_CACHED_DEVICE_UPTIME, 0L);
+        Log.d(TAG,
+              String.format(Locale.getDefault(),
+                            "now (disk) [%s] now (sntp) [%s] diff [%f]",
+                            nowDisk,
+                            nowSntp,
+                            (nowDisk - nowSntp) / 1000F));
 
         return new Date(now);
     }
 
-    public static boolean isInitialized() {
-        return INSTANCE._sntpInitialized;
+    public static void clearCachedInfo(SharedPreferences preferences) {
+        if (preferences == null) {
+            return;
+        }
+        preferences.edit().remove(KEY_CACHED_BOOT_TIME).apply();
+        preferences.edit().remove(KEY_CACHED_DEVICE_UPTIME).apply();
+        preferences.edit().remove(KEY_CACHED_SNTP_TIME).apply();
     }
 
-    // -----------------------------------------------------------------------------------
+    public static boolean isInitialized() {
+        return _isSntpInitialized() || _isTrueTimeCachedFromAPreviousBoot();
+    }
+
+    /**
+     * Cache TrueTime initialization information in SharedPreferences
+     * This can help avoid additional TrueTime initialization on app kills
+     */
+    public synchronized TrueTime withSharedPreferences(SharedPreferences preferences) {
+        sharedPreferences = preferences;
+        INSTANCE.sharedPreferences = preferences;
+        return INSTANCE;
+    }
 
     public synchronized TrueTime withConnectionTimeout(int timeoutInMillis) {
+        udpSocketTimeoutInMillis = timeoutInMillis;
         INSTANCE.udpSocketTimeoutInMillis = timeoutInMillis;
         return INSTANCE;
     }
@@ -51,23 +94,118 @@ public class TrueTime {
         return INSTANCE;
     }
 
-    public void initialize() {
-        SntpClient sntpClient = new SntpClient();
-
-        try {
-            sntpClient.requestTime(INSTANCE._ntpHost, INSTANCE.udpSocketTimeoutInMillis);
-            Log.i(TAG, "---- SNTP request successful");
-            setSntpClient(sntpClient);
-        } catch (IOException e) {
-            Log.e(TAG, "TrueTime initialization failed", new Throwable(e));
-            _sntpInitialized = false;
-        }
+    public void initialize() throws IOException {
+        initialize(_ntpHost);
+        cacheTrueTimeInfo(sharedPreferences);
     }
 
     // -----------------------------------------------------------------------------------
 
-    protected synchronized static void setSntpClient(SntpClient sntpClient) {
+    protected void initialize(String ntpHost) throws IOException {
+        if (isInitialized()) {
+            Log.i(TAG, "---- TrueTime already initialized from previous boot/init");
+            Log.i(TAG,
+                  String.format(Locale.getDefault(),
+                                "Sntp initialized [%b], TrueTime Info in disk [%b]",
+                                _isSntpInitialized(),
+                                _isTrueTimeCachedFromAPreviousBoot()));
+            return;
+        }
+
+        SntpClient sntpClient = new SntpClient();
+        try {
+            sntpClient.requestTime(ntpHost, udpSocketTimeoutInMillis);
+            Log.i(TAG, "---- SNTP request successful");
+            _setSntpClient(sntpClient);
+        } catch (IOException e) {
+            Log.e(TAG, "TrueTime initialization failed", new Throwable(e));
+            _sntpInitialized = false;
+            throw e;
+        }
+    }
+
+    protected synchronized static void cacheTrueTimeInfo(SharedPreferences preferences) {
+        if (preferences == null) {
+            Log.d(TAG, "Preferences unavailable. cannot utilize disk info");
+            return;
+        }
+
+        long cachedSntpTime = _getCachedSntpTime();
+        long cachedDeviceUptime = _getCachedDeviceUptime();
+        long bootTime = cachedSntpTime - cachedDeviceUptime;
+
+        Log.d(TAG,
+              String.format("Caching true time info to disk sntp [%s] device [%s] boot [%s]",
+                            cachedSntpTime,
+                            cachedDeviceUptime,
+                            bootTime));
+
+        preferences.edit().putLong(KEY_CACHED_BOOT_TIME, bootTime).apply();
+        preferences.edit().putLong(KEY_CACHED_DEVICE_UPTIME, cachedDeviceUptime).apply();
+        preferences.edit().putLong(KEY_CACHED_SNTP_TIME, cachedSntpTime).apply();
+    }
+
+    // -----------------------------------------------------------------------------------
+
+    private synchronized static void _setSntpClient(SntpClient sntpClient) {
         INSTANCE._sntpClient = sntpClient;
         INSTANCE._sntpInitialized = true;
+    }
+
+    private static boolean _isSntpInitialized() {
+        return INSTANCE._sntpInitialized;
+    }
+
+    private static boolean _isTrueTimeCachedFromAPreviousBoot() {
+        SharedPreferences preferences = INSTANCE.sharedPreferences;
+
+        if (preferences == null) {
+            return false;
+        }
+
+        long cachedBootTime = preferences.getLong(KEY_CACHED_BOOT_TIME, 0L);
+        if (cachedBootTime == 0) {
+            return false;
+        }
+
+        // has boot time changed
+        long cachedSntpTime = INSTANCE.sharedPreferences.getLong(KEY_CACHED_SNTP_TIME, 0L);
+        long cachedDeviceUptime = INSTANCE.sharedPreferences.getLong(KEY_CACHED_DEVICE_UPTIME, 0L);
+        long deviceUptime = SystemClock.elapsedRealtime();
+        long nowAccordingToCachedTrueTime = cachedSntpTime + (deviceUptime - cachedDeviceUptime);
+        long currentBootTime = nowAccordingToCachedTrueTime - deviceUptime;
+
+        boolean bootTimeSame = currentBootTime == cachedBootTime;
+        Log.i(TAG, "boot time changed " + !bootTimeSame);
+
+        return bootTimeSame;
+    }
+
+    private static long _getCachedDeviceUptime() {
+        if (_isSntpInitialized()) {
+            return INSTANCE._sntpClient.getCachedDeviceUptime();
+        }
+
+        long cachedDeviceUptime = INSTANCE.sharedPreferences.getLong(KEY_CACHED_DEVICE_UPTIME, 0L);
+
+        if (cachedDeviceUptime == 0L) {
+            throw new RuntimeException("expected SNTP time from last boot to be cached. couldn't find it.");
+        }
+
+        return cachedDeviceUptime;
+    }
+
+    private static long _getCachedSntpTime() {
+        if (_isSntpInitialized()) {
+            return INSTANCE._sntpClient.getCachedSntpTime();
+        }
+
+        long cachedSntpTime = INSTANCE.sharedPreferences.getLong(KEY_CACHED_SNTP_TIME, 0L);
+
+        if (cachedSntpTime == 0L) {
+            throw new RuntimeException("expected SNTP time from last boot to be cached. couldn't find it.");
+        }
+
+        return cachedSntpTime;
     }
 }

--- a/library/src/main/java/com/instacart/library/truetime/TrueTime.java
+++ b/library/src/main/java/com/instacart/library/truetime/TrueTime.java
@@ -5,7 +5,6 @@ import android.os.SystemClock;
 import android.util.Log;
 import java.io.IOException;
 import java.util.Date;
-import java.util.Locale;
 
 public class TrueTime {
 
@@ -30,30 +29,12 @@ public class TrueTime {
         long cachedSntpTime = _getCachedSntpTime();
         long cachedDeviceUptime = _getCachedDeviceUptime();
         long deviceUptime = SystemClock.elapsedRealtime();
-
         long now = cachedSntpTime + (deviceUptime - cachedDeviceUptime);
-
-        // -----------------------------------------------------------------------------------
-        // hacking
-        long nowSntp = (getSntpClient() != null) ? getSntpClient().getCachedSntpTime() + deviceUptime -
-                                                   getSntpClient().getCachedDeviceUptime() : 0L;
-        long nowDisk = getDiskCacheClient().getCachedSntpTime() + deviceUptime -
-                       getDiskCacheClient().getCachedDeviceUptime();
-        Log.d(TAG,
-              String.format(Locale.getDefault(),
-                            "now (disk) [%s] now (sntp) [%s] diff [%f]",
-                            nowDisk,
-                            nowSntp,
-                            (nowDisk - nowSntp) / 1000F));
-        // -----------------------------------------------------------------------------------
 
         return new Date(now);
     }
 
     public static boolean isInitialized() {
-        //hacking
-        Log.d("kg", "SNTP initialized " + _isSntpInitialized() + " disk info available " + getDiskCacheClient().isTrueTimeCachedFromAPreviousBoot());
-        return _isSntpInitialized() || getDiskCacheClient().isTrueTimeCachedFromAPreviousBoot();
         return SNTP_CLIENT.wasInitialized() || DISK_CACHE_CLIENT.isTrueTimeCachedFromAPreviousBoot();
     }
 

--- a/library/src/main/java/com/instacart/library/truetime/TrueTime.java
+++ b/library/src/main/java/com/instacart/library/truetime/TrueTime.java
@@ -1,6 +1,6 @@
 package com.instacart.library.truetime;
 
-import android.content.SharedPreferences;
+import android.content.Context;
 import android.os.SystemClock;
 import android.util.Log;
 import java.io.IOException;
@@ -42,8 +42,8 @@ public class TrueTime {
         return INSTANCE;
     }
 
-    public static void clearCachedInfo(SharedPreferences preferences) {
-        DISK_CACHE_CLIENT.clearCachedInfo(preferences);
+    public static void clearCachedInfo(Context context) {
+        DISK_CACHE_CLIENT.clearCachedInfo(context);
     }
 
     public void initialize() throws IOException {
@@ -55,8 +55,8 @@ public class TrueTime {
      * Cache TrueTime initialization information in SharedPreferences
      * This can help avoid additional TrueTime initialization on app kills
      */
-    public synchronized TrueTime withSharedPreferences(SharedPreferences preferences) {
-        DISK_CACHE_CLIENT.setSource(preferences);
+    public synchronized TrueTime withSharedPreferences(Context context) {
+        DISK_CACHE_CLIENT.enableDiskCaching(context);
         return INSTANCE;
     }
 
@@ -82,12 +82,11 @@ public class TrueTime {
 
     protected synchronized static void cacheTrueTimeInfo() {
         if (!SNTP_CLIENT.wasInitialized()) {
-            Log.w(TAG, "SNTP client info not available. cannot cache TrueTime info in disk");
+            Log.i(TAG, "---- SNTP client not available. not caching TrueTime info in disk");
             return;
         }
 
-        SntpClient sntpClient = SNTP_CLIENT;
-        DISK_CACHE_CLIENT.cacheTrueTimeInfo(sntpClient);
+        DISK_CACHE_CLIENT.cacheTrueTimeInfo(SNTP_CLIENT);
     }
 
     private static long _getCachedDeviceUptime() {

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">TrueTime for Android</string>
+    <string name="tt_time_gmt">TrueTime: %1$s [GMT]</string>
+    <string name="tt_time_pst">TrueTime: %1$s [PST]</string>
+    <string name="tt_time_device">Device Time: %1$s [PST]</string>
 </resources>


### PR DESCRIPTION
This PR allows TrueTime info to be cached in disk. We never really need to make another SNTP request if even one of the requests made it through. The cached information is invalid only upon the next boot (since the device uptime would no longer be correct).


- [x] refactor caching by composing a service/helper
- [x] when shared preferences not provided, don't crash - just fall back to not persisting
- [x] test different cases work:

1. SNTP & disk info not available
2. SNTP & disk available
3. disk available (post app killed)
4. disk available (post boot)