### PR TITLE
Setter for Acceptable Server Response Delay

### DIFF
--- a/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
+++ b/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
@@ -42,6 +42,11 @@ public class TrueTimeRx
         return this;
     }
 
+    public TrueTimeRx withServerResponseTimeout(int timeout) {
+        super.withServerResponseTimeout(timeout);
+        return this;
+    }
+
     public TrueTimeRx withLoggingEnabled(boolean isLoggingEnabled) {
         super.withLoggingEnabled(isLoggingEnabled);
         return this;

--- a/library/src/main/java/com/instacart/library/truetime/SntpClient.java
+++ b/library/src/main/java/com/instacart/library/truetime/SntpClient.java
@@ -80,10 +80,11 @@ public class SntpClient {
     /**
      * Sends an NTP request to the given host and processes the response.
      *
-     * @param ntpHost         host name of the server.
-     * @param timeoutInMillis network timeout in milliseconds.
+     * @param ntpHost                       host name of the server.
+     * @param timeoutInMillis               network timeout in milliseconds.
+     * @param serverResponseTimeoutInMillis threshold for server response delay in milliseconds.
      */
-    long[] requestTime(String ntpHost, int timeoutInMillis) throws IOException {
+    long[] requestTime(String ntpHost, int timeoutInMillis, int serverResponseTimeoutInMillis) throws IOException {
 
         DatagramSocket socket = null;
 
@@ -167,7 +168,7 @@ public class SntpClient {
             }
 
             long delay = Math.abs((responseTime - originateTime) - (transmitTime - receiveTime));
-            if (delay >= 100) {
+            if (delay >= serverResponseTimeoutInMillis) {
                 throw new InvalidNtpServerResponseException("Server response delay too large for comfort " + delay);
             }
 

--- a/library/src/main/java/com/instacart/library/truetime/TrueTime.java
+++ b/library/src/main/java/com/instacart/library/truetime/TrueTime.java
@@ -14,6 +14,7 @@ public class TrueTime {
     private static final SntpClient SNTP_CLIENT = new SntpClient();
 
     private static int _udpSocketTimeoutInMillis = 30_000;
+    private static int _serverResponseTimeoutInMillis = 100;
 
     private String _ntpHost = "1.us.pool.ntp.org";
 
@@ -64,6 +65,11 @@ public class TrueTime {
         return INSTANCE;
     }
 
+    public synchronized TrueTime withServerResponseTimeout(int timeoutInMillis) {
+        _serverResponseTimeoutInMillis = timeoutInMillis;
+        return INSTANCE;
+    }
+
     public synchronized TrueTime withNtpHost(String ntpHost) {
         _ntpHost = ntpHost;
         return INSTANCE;
@@ -86,7 +92,7 @@ public class TrueTime {
     }
 
     long[] requestTime(String ntpHost) throws IOException {
-        return SNTP_CLIENT.requestTime(ntpHost, _udpSocketTimeoutInMillis);
+        return SNTP_CLIENT.requestTime(ntpHost, _udpSocketTimeoutInMillis, _serverResponseTimeoutInMillis);
     }
 
     synchronized static void saveTrueTimeInfoToDisk() {


### PR DESCRIPTION
Maybe there's a reason why the server response delay has to be under 100 ms. However, on some Android devices the library never get initialized because the response delay is never under 100. Issues #45 and #54 are most likely related.
