### PR TITLE
feat: provide apis for server response delays

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip

--- a/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
+++ b/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
@@ -42,6 +42,16 @@ public class TrueTimeRx
         return this;
     }
 
+    public TrueTimeRx withRootDelayMax(int rootDelay) {
+        super.withRootDelayMax(rootDelay);
+        return this;
+    }
+
+    public TrueTimeRx withRootDispersionMax(int rootDispersion) {
+        super.withRootDispersionMax(rootDispersion);
+        return this;
+    }
+
     public TrueTimeRx withServerResponseDelayMax(int serverResponseDelayInMillis) {
         super.withServerResponseDelayMax(serverResponseDelayInMillis);
         return this;

--- a/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
+++ b/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
@@ -215,7 +215,6 @@ public class TrueTimeRx
                       })
                       .toList()
                       .toFlowable()
-                      .onErrorResumeNext(Flowable.<List<long[]>>empty())
                       .map(filterLeastRoundTripDelay()); // pick best response for each ip
             }
         };

--- a/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
+++ b/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
@@ -42,6 +42,11 @@ public class TrueTimeRx
         return this;
     }
 
+    public TrueTimeRx withServerResponseDelayMax(int serverResponseDelayInMillis) {
+        super.withServerResponseDelayMax(serverResponseDelayInMillis);
+        return this;
+    }
+
     public TrueTimeRx withLoggingEnabled(boolean isLoggingEnabled) {
         super.withLoggingEnabled(isLoggingEnabled);
         return this;

--- a/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
+++ b/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
@@ -42,12 +42,12 @@ public class TrueTimeRx
         return this;
     }
 
-    public TrueTimeRx withRootDelayMax(int rootDelay) {
+    public TrueTimeRx withRootDelayMax(float rootDelay) {
         super.withRootDelayMax(rootDelay);
         return this;
     }
 
-    public TrueTimeRx withRootDispersionMax(int rootDispersion) {
+    public TrueTimeRx withRootDispersionMax(float rootDispersion) {
         super.withRootDispersionMax(rootDispersion);
         return this;
     }

--- a/library/src/main/java/com/instacart/library/truetime/InvalidNtpServerResponseException.java
+++ b/library/src/main/java/com/instacart/library/truetime/InvalidNtpServerResponseException.java
@@ -1,10 +1,43 @@
 package com.instacart.library.truetime;
 
 import java.io.IOException;
+import java.util.Locale;
 
 public class InvalidNtpServerResponseException
       extends IOException {
+
+    public final String property;
+    public final float expectedValue;
+    public final float actualValue;
+
     InvalidNtpServerResponseException(String detailMessage) {
         super(detailMessage);
+
+        this.property = "na";
+        this.expectedValue = 0F;
+        this.actualValue = 0F;
     }
+
+  /**
+   *
+   * @param message An informative message that api users can use to know what went wrong.
+   *                should contain {@link this#property} {@link this#expectedValue} and
+   *                {@link this#actualValue} as format specifiers (in that order)
+   * @param property  property that caused the invalid NTP response
+   */
+  InvalidNtpServerResponseException(String message,
+      String property,
+      float actualValue,
+      float expectedValue) {
+
+      super(String.format(Locale.getDefault(),
+          message,
+          property,
+          actualValue,
+          expectedValue));
+
+      this.property = property;
+      this.actualValue = actualValue;
+      this.expectedValue = expectedValue;
+   }
 }

--- a/library/src/main/java/com/instacart/library/truetime/SntpClient.java
+++ b/library/src/main/java/com/instacart/library/truetime/SntpClient.java
@@ -58,9 +58,9 @@ public class SntpClient {
     private static final int ROOT_DISPERSION = ROOT_DELAY;
     private static final int SERVER_RESPONSE_DELAY = ROOT_DELAY;
 
-    private volatile long _cachedDeviceUptime;
-    private volatile long _cachedSntpTime;
-    private volatile boolean _sntpInitialized = false;
+    private long _cachedDeviceUptime;
+    private long _cachedSntpTime;
+    private boolean _sntpInitialized = false;
 
     /**
      * See δ :

--- a/library/src/main/java/com/instacart/library/truetime/SntpClient.java
+++ b/library/src/main/java/com/instacart/library/truetime/SntpClient.java
@@ -56,7 +56,6 @@ public class SntpClient {
     private static final long OFFSET_1900_TO_1970 = ((365L * 70L) + 17L) * 24L * 60L * 60L;
     private static final int ROOT_DELAY = 200;
     private static final int ROOT_DISPERSION = ROOT_DELAY;
-    private static final int SERVER_RESPONSE_DELAY = ROOT_DELAY;
 
     private long _cachedDeviceUptime;
     private long _cachedSntpTime;
@@ -86,7 +85,8 @@ public class SntpClient {
      * @param ntpHost         host name of the server.
      * @param timeoutInMillis network timeout in milliseconds.
      */
-    synchronized long[] requestTime(String ntpHost, int timeoutInMillis) throws IOException {
+    synchronized long[] requestTime(String ntpHost, int timeoutInMillis, int serverResponseDelay)
+        throws IOException {
 
         DatagramSocket socket = null;
 
@@ -170,7 +170,7 @@ public class SntpClient {
             }
 
             long delay = Math.abs((responseTime - originateTime) - (transmitTime - receiveTime));
-            if (delay >= SERVER_RESPONSE_DELAY) {
+            if (delay >= serverResponseDelay) {
                 throw new InvalidNtpServerResponseException("Server response delay too large for comfort " + delay);
             }
 

--- a/library/src/main/java/com/instacart/library/truetime/TrueTime.java
+++ b/library/src/main/java/com/instacart/library/truetime/TrueTime.java
@@ -14,8 +14,8 @@ public class TrueTime {
     private static final DiskCacheClient DISK_CACHE_CLIENT = new DiskCacheClient();
     private static final SntpClient SNTP_CLIENT = new SntpClient();
 
-    private static int _rootDelayMax = 100;
-    private static int _rootDispersionMax = 100;
+    private static float _rootDelayMax = 100;
+    private static float _rootDispersionMax = 100;
     private static int _serverResponseDelayMax = 200;
     private static int _udpSocketTimeoutInMillis = 30_000;
 
@@ -67,11 +67,11 @@ public class TrueTime {
         _udpSocketTimeoutInMillis = timeoutInMillis;
         return INSTANCE;
     }
-  
-    public synchronized TrueTime withRootDelayMax(int rootDelayMax) {
+
+    public synchronized TrueTime withRootDelayMax(float rootDelayMax) {
         if (rootDelayMax > _rootDelayMax) {
           String log = String.format(Locale.getDefault(),
-              "The recommended max rootDelay value is %d. You are setting it at %d",
+              "The recommended max rootDelay value is %f. You are setting it at %f",
               _rootDelayMax, rootDelayMax);
           TrueLog.w(TAG, log);
         }
@@ -80,10 +80,10 @@ public class TrueTime {
         return INSTANCE;
     }
 
-    public synchronized TrueTime withRootDispersionMax(int rootDispersionMax) {
+    public synchronized TrueTime withRootDispersionMax(float rootDispersionMax) {
       if (rootDispersionMax > _rootDispersionMax) {
         String log = String.format(Locale.getDefault(),
-            "The recommended max rootDispersion value is %d. You are setting it at %d",
+            "The recommended max rootDispersion value is %f. You are setting it at %f",
             _rootDispersionMax, rootDispersionMax);
         TrueLog.w(TAG, log);
       }

--- a/library/src/main/java/com/instacart/library/truetime/TrueTime.java
+++ b/library/src/main/java/com/instacart/library/truetime/TrueTime.java
@@ -14,6 +14,7 @@ public class TrueTime {
     private static final SntpClient SNTP_CLIENT = new SntpClient();
 
     private static int _udpSocketTimeoutInMillis = 30_000;
+    private static int _serverResponseDelayMax = 200;
 
     private String _ntpHost = "1.us.pool.ntp.org";
 
@@ -64,6 +65,11 @@ public class TrueTime {
         return INSTANCE;
     }
 
+    public synchronized TrueTime withServerResponseDelayMax(int serverResponseDelayInMillis) {
+        _serverResponseDelayMax = serverResponseDelayInMillis;
+        return INSTANCE;
+    }
+
     public synchronized TrueTime withNtpHost(String ntpHost) {
         _ntpHost = ntpHost;
         return INSTANCE;
@@ -86,7 +92,8 @@ public class TrueTime {
     }
 
     long[] requestTime(String ntpHost) throws IOException {
-        return SNTP_CLIENT.requestTime(ntpHost, _udpSocketTimeoutInMillis);
+        return SNTP_CLIENT
+            .requestTime(ntpHost, _udpSocketTimeoutInMillis, _serverResponseDelayMax);
     }
 
     synchronized static void saveTrueTimeInfoToDisk() {


### PR DESCRIPTION
* provide api for server response delay max (millis)
* provide root delay and root dispersion as api inputs (millis)
* fix: propagate `InvalidNtpServerRespnoseException` properly
* make sure `InvalidNtpServerRespnoseException` sends up property violated with values

closes #54 