### PR TITLE
Provide customized TrueTime cache interface 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ dependencies {
 ## Vanilla version
 
 Importing `'com.github.instacart.truetime-android:library:<release-version>'` should be sufficient for this.
+
 Then you must initialize it in ```onCreate()``` in your class that extends```android.app.Application```.
 ```java
 TrueTime.build().initialize();
 ```
 
-`initialize` must be run on a background thread. If you run it on the main thread, you will get a [`NetworkOnMainThreadException`](https://developer.android.com/reference/android/os/NetworkOnMainThreadException.html)
+`initialize` also must be run on a background thread. If you run it on the main thread, you will get a [`NetworkOnMainThreadException`](https://developer.android.com/reference/android/os/NetworkOnMainThreadException.html)
 
 You can then use:
 
@@ -65,6 +66,7 @@ Date noReallyThisIsTheTrueDateAndTime = TrueTime.now();
 ## Rx-ified Version
 
 If you're down to using [RxJava](https://github.com/ReactiveX/RxJava) then we go all the way and implement the full NTP. Use the nifty `initializeRx()` api which takes in an NTP pool server host.
+
 Again, you must initialize it in ```onCreate()``` in your class that extends```android.app.Application```.
 
 ```java

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ dependencies {
 ## Vanilla version
 
 Importing `'com.github.instacart.truetime-android:library:<release-version>'` should be sufficient for this.
-
+Then you must initialize it in ```onCreate()``` in your class that extends```android.app.Application```.
 ```java
 TrueTime.build().initialize();
 ```
@@ -65,6 +65,7 @@ Date noReallyThisIsTheTrueDateAndTime = TrueTime.now();
 ## Rx-ified Version
 
 If you're down to using [RxJava](https://github.com/ReactiveX/RxJava) then we go all the way and implement the full NTP. Use the nifty `initializeRx()` api which takes in an NTP pool server host.
+Again, you must initialize it in ```onCreate()``` in your class that extends```android.app.Application```.
 
 ```java
 TrueTimeRx.build()
@@ -93,7 +94,7 @@ TrueTimeRx.now(); // return a Date object with the "true" time.
 
 ## Notes/tips:
 
-* Each `initialize` call makes an SNTP network request. TrueTime needs to be `initialize`d only once ever, per device boot. Use TrueTime's `withSharedPreferences` option to make use of this feature and avoid repeated network request calls.
+* Each `initialize` call makes an SNTP network request. TrueTime needs to be `initialize`d only once ever, per device boot. Use TrueTime's `withSharedPreferencesCache` option to make use of this feature and avoid repeated network request calls.
 * Preferable use dependency injection (like [Dagger](http://square.github.io/dagger/)) and create a TrueTime @Singleton object
 * You can read up on Wikipedia the differences between [SNTP](https://en.wikipedia.org/wiki/Network_Time_Protocol#SNTP) and [NTP](https://www.meinbergglobal.com/english/faq/faq_37.htm).
 * TrueTime is also [available for iOS/Swift](https://github.com/instacart/truetime.swift)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
+        android:name=".App"
         android:theme="@style/AppTheme">
 
         <activity android:name=".Sample2Activity">

--- a/app/src/main/java/com/instacart/library/sample/App.java
+++ b/app/src/main/java/com/instacart/library/sample/App.java
@@ -1,0 +1,47 @@
+package com.instacart.library.sample;
+
+import android.app.Application;
+import android.util.Log;
+
+import com.instacart.library.truetime.TrueTimeRx;
+
+import java.util.Date;
+
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.observers.DisposableSingleObserver;
+import io.reactivex.schedulers.Schedulers;
+
+public class App extends Application {
+
+    private static final String TAG = App.class.getSimpleName();
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        initRxTrueTime();
+    }
+
+    private void initRxTrueTime() {
+        TrueTimeRx.build()
+                .withConnectionTimeout(31_428)
+                .withRetryCount(100)
+                .withSharedPreferencesCache(getApplicationContext())
+                .withLoggingEnabled(true)
+                .initializeRx("time.google.com")
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeWith(new DisposableSingleObserver<Date>() {
+                    @Override
+                    public void onSuccess(Date date) {
+                        Log.d(TAG, "Success initialized TrueTime :" + date.toString());
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        Log.e(TAG, "something went wrong when trying to initializeRx TrueTime", e);
+                    }
+                });
+    }
+
+
+}

--- a/app/src/main/java/com/instacart/library/sample/App.java
+++ b/app/src/main/java/com/instacart/library/sample/App.java
@@ -1,10 +1,13 @@
 package com.instacart.library.sample;
 
 import android.app.Application;
+import android.os.AsyncTask;
 import android.util.Log;
 
+import com.instacart.library.truetime.TrueTime;
 import com.instacart.library.truetime.TrueTimeRx;
 
+import java.io.IOException;
 import java.util.Date;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -19,10 +22,40 @@ public class App extends Application {
     public void onCreate() {
         super.onCreate();
         initRxTrueTime();
+//        initTrueTime();
     }
 
+    /**
+     * init the TrueTime using a AsyncTask.
+     */
+    private void initTrueTime() {
+        new InitTrueTimeAsyncTask().execute();
+    }
+
+    // a little part of me died, having to use this
+    private static class InitTrueTimeAsyncTask extends AsyncTask<Void, Void, Void> {
+
+        protected Void doInBackground(Void... params) {
+            try {
+                TrueTime.build()
+                        //.withSharedPreferences(SampleActivity.this)
+                        .withNtpHost("time.google.com")
+                        .withLoggingEnabled(false)
+                        .withConnectionTimeout(3_1428)
+                        .initialize();
+            } catch (IOException e) {
+                e.printStackTrace();
+                Log.e(TAG, "something went wrong when trying to initialize TrueTime", e);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Initialize the TrueTime using RxJava.
+     */
     private void initRxTrueTime() {
-        TrueTimeRx.build()
+        DisposableSingleObserver<Date> disposable = TrueTimeRx.build()
                 .withConnectionTimeout(31_428)
                 .withRetryCount(100)
                 .withSharedPreferencesCache(getApplicationContext())

--- a/app/src/main/java/com/instacart/library/sample/App.java
+++ b/app/src/main/java/com/instacart/library/sample/App.java
@@ -33,7 +33,7 @@ public class App extends Application {
     }
 
     // a little part of me died, having to use this
-    private static class InitTrueTimeAsyncTask extends AsyncTask<Void, Void, Void> {
+    private class InitTrueTimeAsyncTask extends AsyncTask<Void, Void, Void> {
 
         protected Void doInBackground(Void... params) {
             try {
@@ -41,6 +41,7 @@ public class App extends Application {
                         //.withSharedPreferences(SampleActivity.this)
                         .withNtpHost("time.google.com")
                         .withLoggingEnabled(false)
+                        .withSharedPreferencesCache(App.this)
                         .withConnectionTimeout(3_1428)
                         .initialize();
             } catch (IOException e) {
@@ -58,7 +59,7 @@ public class App extends Application {
         DisposableSingleObserver<Date> disposable = TrueTimeRx.build()
                 .withConnectionTimeout(31_428)
                 .withRetryCount(100)
-                .withSharedPreferencesCache(getApplicationContext())
+                .withSharedPreferencesCache(this)
                 .withLoggingEnabled(true)
                 .initializeRx("time.google.com")
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
+++ b/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
@@ -19,8 +19,7 @@ import butterknife.Bind;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.functions.Action;
-import io.reactivex.functions.Consumer;
+import io.reactivex.observers.DisposableSingleObserver;
 import io.reactivex.schedulers.Schedulers;
 
 public class Sample2Activity
@@ -53,23 +52,19 @@ public class Sample2Activity
               .initializeRx("time.google.com")
               .subscribeOn(Schedulers.io())
               .observeOn(AndroidSchedulers.mainThread())
-              .subscribe(new Consumer<Date>() {
-                  @Override
-                  public void accept(Date date) {
-                      onBtnRefresh();
-                  }
-              }, new Consumer<Throwable>() {
-                  @Override
-                  public void accept(Throwable throwable) {
-                      updateTime();
-                      Log.e(TAG, "something went wrong when trying to initializeRx TrueTime", throwable);
-                  }
-              }, new Action() {
-                  @Override
-                  public void run() {
-                      refreshBtn.setEnabled(true);
-                  }
-              });
+              .subscribeWith(new DisposableSingleObserver<Date>() {
+                    @Override
+                    public void onSuccess(Date date) {
+                        onBtnRefresh();
+                        refreshBtn.setEnabled(true);
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        updateTime();
+                        Log.e(TAG, "something went wrong when trying to initializeRx TrueTime", e);
+                    }
+        });
     }
 
     @OnClick(R.id.tt_btn_refresh)

--- a/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
+++ b/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
@@ -18,14 +18,9 @@ import java.util.TimeZone;
 import butterknife.Bind;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
-import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.observers.DisposableSingleObserver;
-import io.reactivex.schedulers.Schedulers;
 
 public class Sample2Activity
       extends AppCompatActivity {
-
-    private static final String TAG = Sample2Activity.class.getSimpleName();
 
     @Bind(R.id.tt_btn_refresh) Button refreshBtn;
     @Bind(R.id.tt_time_gmt) TextView timeGMT;
@@ -40,31 +35,7 @@ public class Sample2Activity
         getSupportActionBar().setTitle("TrueTimeRx");
 
         ButterKnife.bind(this);
-        refreshBtn.setEnabled(false);
-
-        //TrueTimeRx.clearCachedInfo(this);
-
-        TrueTimeRx.build()
-              .withConnectionTimeout(31_428)
-              .withRetryCount(100)
-              .withSharedPreferencesCache(getApplicationContext())
-              .withLoggingEnabled(true)
-              .initializeRx("time.google.com")
-              .subscribeOn(Schedulers.io())
-              .observeOn(AndroidSchedulers.mainThread())
-              .subscribeWith(new DisposableSingleObserver<Date>() {
-                    @Override
-                    public void onSuccess(Date date) {
-                        onBtnRefresh();
-                        refreshBtn.setEnabled(true);
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                        updateTime();
-                        Log.e(TAG, "something went wrong when trying to initializeRx TrueTime", e);
-                    }
-        });
+        refreshBtn.setEnabled(TrueTimeRx.isInitialized());
     }
 
     @OnClick(R.id.tt_btn_refresh)

--- a/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
+++ b/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
@@ -48,7 +48,7 @@ public class Sample2Activity
         TrueTimeRx.build()
               .withConnectionTimeout(31_428)
               .withRetryCount(100)
-              .withSharedPreferences(this)
+              .withSharedPreferencesCache(getApplicationContext())
               .withLoggingEnabled(true)
               .initializeRx("time.google.com")
               .subscribeOn(Schedulers.io())
@@ -61,6 +61,7 @@ public class Sample2Activity
               }, new Consumer<Throwable>() {
                   @Override
                   public void accept(Throwable throwable) {
+                      updateTime();
                       Log.e(TAG, "something went wrong when trying to initializeRx TrueTime", throwable);
                   }
               }, new Action() {
@@ -73,11 +74,15 @@ public class Sample2Activity
 
     @OnClick(R.id.tt_btn_refresh)
     public void onBtnRefresh() {
+        updateTime();
+    }
+
+    private void updateTime() {
         if (!TrueTimeRx.isInitialized()) {
             Toast.makeText(this, "Sorry TrueTime not yet initialized.", Toast.LENGTH_SHORT).show();
             return;
         }
-
+        refreshBtn.setEnabled(true);
         Date trueTime = TrueTimeRx.now();
         Date deviceTime = new Date();
 

--- a/app/src/main/java/com/instacart/library/sample/SampleActivity.java
+++ b/app/src/main/java/com/instacart/library/sample/SampleActivity.java
@@ -1,15 +1,13 @@
 package com.instacart.library.sample;
 
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
+import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import com.instacart.library.truetime.TrueTime;
 
-import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -23,8 +21,7 @@ import butterknife.OnClick;
 public class SampleActivity
       extends AppCompatActivity {
 
-    private static final String TAG = SampleActivity.class.getSimpleName();
-
+    @Bind(R.id.tt_btn_refresh) Button refreshBtn;
     @Bind(R.id.tt_time_gmt) TextView timeGMT;
     @Bind(R.id.tt_time_pst) TextView timePST;
     @Bind(R.id.tt_time_device) TextView timeDeviceTime;
@@ -33,17 +30,14 @@ public class SampleActivity
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_sample);
-
-        new InitTrueTimeAsyncTask().execute();
-
         ButterKnife.bind(this);
+        refreshBtn.setEnabled(TrueTime.isInitialized());
     }
 
     @OnClick(R.id.tt_btn_refresh)
     public void onBtnRefresh() {
         if (!TrueTime.isInitialized()) {
             Toast.makeText(this, "Sorry TrueTime not yet initialized. Trying again.", Toast.LENGTH_SHORT).show();
-            new InitTrueTimeAsyncTask().execute();
             return;
         }
 
@@ -62,26 +56,6 @@ public class SampleActivity
         DateFormat format = new SimpleDateFormat(pattern, Locale.ENGLISH);
         format.setTimeZone(timeZone);
         return format.format(date);
-    }
-
-    // a little part of me died, having to use this
-    private class InitTrueTimeAsyncTask
-          extends AsyncTask<Void, Void, Void> {
-
-        protected Void doInBackground(Void... params) {
-            try {
-                TrueTime.build()
-                      //.withSharedPreferences(SampleActivity.this)
-                      .withNtpHost("time.google.com")
-                      .withLoggingEnabled(false)
-                      .withConnectionTimeout(3_1428)
-                      .initialize();
-            } catch (IOException e) {
-                e.printStackTrace();
-                Log.e(TAG, "Exception when trying to get TrueTime", e);
-            }
-            return null;
-        }
     }
 
 }

--- a/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
+++ b/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
@@ -6,6 +6,7 @@ import io.reactivex.Flowable;
 import io.reactivex.FlowableEmitter;
 import io.reactivex.FlowableOnSubscribe;
 import io.reactivex.FlowableTransformer;
+import io.reactivex.Single;
 import io.reactivex.annotations.NonNull;
 import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
@@ -83,9 +84,9 @@ public class TrueTimeRx
      *
      * @return accurate NTP Date
      */
-    public Flowable<Date> initializeRx(String ntpPoolAddress) {
+    public Single<Date> initializeRx(String ntpPoolAddress) {
         return isInitialized()
-                ? Flowable.just(now())
+                ? Single.just(now())
                 : initializeNtp(ntpPoolAddress).map(new Function<long[], Date>() {
                     @Override
                     public Date apply(long[] longs) throws Exception {
@@ -106,11 +107,12 @@ public class TrueTimeRx
      * @return Observable of detailed long[] containing most important parts of the actual NTP response
      * See RESPONSE_INDEX_ prefixes in {@link SntpClient} for details
      */
-    public Flowable<long[]> initializeNtp(String ntpPool) {
+    public Single<long[]> initializeNtp(String ntpPool) {
         return Flowable
               .just(ntpPool)
               .compose(resolveNtpPoolToIpAddresses())
-              .compose(performNtpAlgorithm());
+              .compose(performNtpAlgorithm())
+              .firstOrError();
     }
 
     /**

--- a/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
+++ b/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
@@ -38,8 +38,14 @@ public class TrueTimeRx
         return this;
     }
 
-    public TrueTimeRx withCustomizedCacheInterface(CacheInterface cacheInterface) {
-        super.withCustomizedCacheInterface(cacheInterface);
+    /**
+     * Provide your own cache interface to cache the true time information.
+     * Please be noted that if you provide such cache interface, it is also your own responsibility
+     * to clear the cache on device reboot. This is a must.
+     * @param cacheInterface the customized cache interface to save the true time data.
+     */
+    public TrueTimeRx withCustomizedCache(CacheInterface cacheInterface) {
+        super.withCustomizedCache(cacheInterface);
         return this;
     }
 

--- a/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
+++ b/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
@@ -80,12 +80,14 @@ public class TrueTimeRx
      * @return accurate NTP Date
      */
     public Flowable<Date> initializeRx(String ntpPoolAddress) {
-        return initializeNtp(ntpPoolAddress).map(new Function<long[], Date>() {
-            @Override
-            public Date apply(long[] longs) throws Exception {
-                return now();
-            }
-        });
+        return isInitialized()
+                ? Flowable.just(now())
+                : initializeNtp(ntpPoolAddress).map(new Function<long[], Date>() {
+                    @Override
+                    public Date apply(long[] longs) throws Exception {
+                        return now();
+                    }
+                });
      }
 
     /**

--- a/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
+++ b/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
@@ -33,8 +33,13 @@ public class TrueTimeRx
         return RX_INSTANCE;
     }
 
-    public TrueTimeRx withSharedPreferences(Context context) {
-        super.withSharedPreferences(context);
+    public TrueTimeRx withSharedPreferencesCache(Context context) {
+        super.withSharedPreferencesCache(context);
+        return this;
+    }
+
+    public TrueTimeRx withCustomizedCacheInterface(CacheInterface cacheInterface) {
+        super.withCustomizedCacheInterface(cacheInterface);
         return this;
     }
 

--- a/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
+++ b/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
@@ -40,8 +40,6 @@ public class TrueTimeRx
 
     /**
      * Provide your own cache interface to cache the true time information.
-     * Please be noted that if you provide such cache interface, it is also your own responsibility
-     * to clear the cache on device reboot. This is a must.
      * @param cacheInterface the customized cache interface to save the true time data.
      */
     public TrueTimeRx withCustomizedCache(CacheInterface cacheInterface) {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -28,7 +28,6 @@ android {
 }
 
 dependencies {
-    compile "com.android.support:support-annotations:25.3.0"
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -28,6 +28,7 @@ android {
 }
 
 dependencies {
+    compile "com.android.support:support-annotations:25.3.0"
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })

--- a/library/src/main/java/com/instacart/library/truetime/BootCompletedBroadcastReceiver.java
+++ b/library/src/main/java/com/instacart/library/truetime/BootCompletedBroadcastReceiver.java
@@ -3,7 +3,6 @@ package com.instacart.library.truetime;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
 
 public class BootCompletedBroadcastReceiver
       extends BroadcastReceiver {
@@ -13,6 +12,6 @@ public class BootCompletedBroadcastReceiver
     @Override
     public void onReceive(Context context, Intent intent) {
         TrueLog.i(TAG, "---- clearing TrueTime disk cache as we've detected a boot");
-        TrueTime.clearCachedInfo(context);
+        TrueTime.clearCachedInfo();
     }
 }

--- a/library/src/main/java/com/instacart/library/truetime/CacheInterface.java
+++ b/library/src/main/java/com/instacart/library/truetime/CacheInterface.java
@@ -1,0 +1,27 @@
+package com.instacart.library.truetime;
+
+import android.support.annotation.StringDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+public interface CacheInterface {
+
+    String KEY_CACHED_BOOT_TIME = "com.instacart.library.truetime.cached_boot_time";
+    String KEY_CACHED_DEVICE_UPTIME = "com.instacart.library.truetime.cached_device_uptime";
+    String KEY_CACHED_SNTP_TIME = "com.instacart.library.truetime.cached_sntp_time";
+
+    void put(@TrueTimeCacheType String key, long value);
+
+    long get(@TrueTimeCacheType String key, long defaultValue);
+
+    void clear();
+
+    @StringDef({KEY_CACHED_BOOT_TIME,
+            KEY_CACHED_DEVICE_UPTIME,
+            KEY_CACHED_SNTP_TIME
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    @interface TrueTimeCacheType {
+    }
+}

--- a/library/src/main/java/com/instacart/library/truetime/CacheInterface.java
+++ b/library/src/main/java/com/instacart/library/truetime/CacheInterface.java
@@ -1,27 +1,16 @@
 package com.instacart.library.truetime;
 
-import android.support.annotation.StringDef;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
 public interface CacheInterface {
 
     String KEY_CACHED_BOOT_TIME = "com.instacart.library.truetime.cached_boot_time";
     String KEY_CACHED_DEVICE_UPTIME = "com.instacart.library.truetime.cached_device_uptime";
     String KEY_CACHED_SNTP_TIME = "com.instacart.library.truetime.cached_sntp_time";
 
-    void put(@TrueTimeCacheType String key, long value);
+    void put(String key, long value);
 
-    long get(@TrueTimeCacheType String key, long defaultValue);
+    long get(String key, long defaultValue);
 
     void clear();
 
-    @StringDef({KEY_CACHED_BOOT_TIME,
-            KEY_CACHED_DEVICE_UPTIME,
-            KEY_CACHED_SNTP_TIME
-    })
-    @Retention(RetentionPolicy.SOURCE)
-    @interface TrueTimeCacheType {
-    }
+
 }

--- a/library/src/main/java/com/instacart/library/truetime/DiskCacheClient.java
+++ b/library/src/main/java/com/instacart/library/truetime/DiskCacheClient.java
@@ -17,12 +17,29 @@ class DiskCacheClient {
         this.cacheInterface = new SharedPreferenceCacheImpl(context);
     }
 
+
+    void clearCachedInfo(Context context) {
+        new SharedPreferenceCacheImpl(context).clear();
+    }
+
+    /**
+     * Provide your own cache interface to cache the true time information.
+     * Please be noted that if you provide such cache interface, it is also your own responsibility
+     * to clear the cache on device reboot. This is a must.
+     * @param cacheInterface the customized cache interface to save the true time data.
+     */
     void enableCacheInterface(CacheInterface cacheInterface) {
         this.cacheInterface = cacheInterface;
     }
 
-    void clearCachedInfo(Context context) {
-        this.cacheInterface.clear();
+    /**
+     * Clear the cache cache when the device is rebooted.
+     * @param cacheInterface the customized cache interface to save the true time data.
+     */
+    void clearCachedInfo(CacheInterface cacheInterface) {
+        if (cacheInterface != null) {
+            cacheInterface.clear();
+        }
     }
 
     void cacheTrueTimeInfo(SntpClient sntpClient) {

--- a/library/src/main/java/com/instacart/library/truetime/DiskCacheClient.java
+++ b/library/src/main/java/com/instacart/library/truetime/DiskCacheClient.java
@@ -14,8 +14,6 @@ class DiskCacheClient {
 
     /**
      * Provide your own cache interface to cache the true time information.
-     * Please be noted that if you provide such cache interface, it is also your own responsibility
-     * to clear the cache on device reboot. This is a must.
      * @param cacheInterface the customized cache interface to save the true time data.
      */
     void enableCacheInterface(CacheInterface cacheInterface) {

--- a/library/src/main/java/com/instacart/library/truetime/DiskCacheClient.java
+++ b/library/src/main/java/com/instacart/library/truetime/DiskCacheClient.java
@@ -35,7 +35,7 @@ class DiskCacheClient {
     }
 
     void cacheTrueTimeInfo(SntpClient sntpClient) {
-        if (sharedPreferencesUnavailable()) {
+        if (cacheUnavailable()) {
             return;
         }
 
@@ -56,7 +56,7 @@ class DiskCacheClient {
     }
 
     boolean isTrueTimeCachedFromAPreviousBoot() {
-        if (sharedPreferencesUnavailable()) {
+        if (cacheUnavailable()) {
             return false;
         }
 
@@ -72,7 +72,7 @@ class DiskCacheClient {
     }
 
     long getCachedDeviceUptime() {
-        if (sharedPreferencesUnavailable()) {
+        if (cacheUnavailable()) {
             return 0L;
         }
 
@@ -80,7 +80,7 @@ class DiskCacheClient {
     }
 
     long getCachedSntpTime() {
-        if (sharedPreferencesUnavailable()) {
+        if (cacheUnavailable()) {
             return 0L;
         }
 
@@ -89,7 +89,7 @@ class DiskCacheClient {
 
     // -----------------------------------------------------------------------------------
 
-    private boolean sharedPreferencesUnavailable() {
+    private boolean cacheUnavailable() {
         if (_cacheInterface == null) {
             TrueLog.w(TAG, "Cannot use disk caching strategy for TrueTime. CacheInterface unavailable");
             return true;

--- a/library/src/main/java/com/instacart/library/truetime/DiskCacheClient.java
+++ b/library/src/main/java/com/instacart/library/truetime/DiskCacheClient.java
@@ -1,6 +1,5 @@
 package com.instacart.library.truetime;
 
-import android.content.Context;
 import android.os.SystemClock;
 
 import static com.instacart.library.truetime.CacheInterface.KEY_CACHED_BOOT_TIME;
@@ -11,16 +10,7 @@ class DiskCacheClient {
 
     private static final String TAG = DiskCacheClient.class.getSimpleName();
 
-    private CacheInterface cacheInterface = null;
-
-    void enableSharedPreferenceCaching(Context context) {
-        this.cacheInterface = new SharedPreferenceCacheImpl(context);
-    }
-
-
-    void clearCachedInfo(Context context) {
-        new SharedPreferenceCacheImpl(context).clear();
-    }
+    private CacheInterface _cacheInterface = null;
 
     /**
      * Provide your own cache interface to cache the true time information.
@@ -29,7 +19,11 @@ class DiskCacheClient {
      * @param cacheInterface the customized cache interface to save the true time data.
      */
     void enableCacheInterface(CacheInterface cacheInterface) {
-        this.cacheInterface = cacheInterface;
+        this._cacheInterface = cacheInterface;
+    }
+
+    void clearCachedInfo() {
+        clearCachedInfo(this._cacheInterface);
     }
 
     /**
@@ -57,9 +51,9 @@ class DiskCacheClient {
                         cachedDeviceUptime,
                         bootTime));
 
-        cacheInterface.put(KEY_CACHED_BOOT_TIME, bootTime);
-        cacheInterface.put(KEY_CACHED_DEVICE_UPTIME, cachedDeviceUptime);
-        cacheInterface.put(KEY_CACHED_SNTP_TIME, cachedSntpTime);
+        _cacheInterface.put(KEY_CACHED_BOOT_TIME, bootTime);
+        _cacheInterface.put(KEY_CACHED_DEVICE_UPTIME, cachedDeviceUptime);
+        _cacheInterface.put(KEY_CACHED_SNTP_TIME, cachedSntpTime);
 
     }
 
@@ -68,7 +62,7 @@ class DiskCacheClient {
             return false;
         }
 
-        long cachedBootTime = cacheInterface.get(KEY_CACHED_BOOT_TIME, 0L);
+        long cachedBootTime = _cacheInterface.get(KEY_CACHED_BOOT_TIME, 0L);
         if (cachedBootTime == 0) {
             return false;
         }
@@ -84,7 +78,7 @@ class DiskCacheClient {
             return 0L;
         }
 
-        return cacheInterface.get(KEY_CACHED_DEVICE_UPTIME, 0L);
+        return _cacheInterface.get(KEY_CACHED_DEVICE_UPTIME, 0L);
     }
 
     long getCachedSntpTime() {
@@ -92,13 +86,13 @@ class DiskCacheClient {
             return 0L;
         }
 
-        return cacheInterface.get(KEY_CACHED_SNTP_TIME, 0L);
+        return _cacheInterface.get(KEY_CACHED_SNTP_TIME, 0L);
     }
 
     // -----------------------------------------------------------------------------------
 
     private boolean sharedPreferencesUnavailable() {
-        if (cacheInterface == null) {
+        if (_cacheInterface == null) {
             TrueLog.w(TAG, "Cannot use disk caching strategy for TrueTime. CacheInterface unavailable");
             return true;
         }

--- a/library/src/main/java/com/instacart/library/truetime/SharedPreferenceCacheImpl.java
+++ b/library/src/main/java/com/instacart/library/truetime/SharedPreferenceCacheImpl.java
@@ -1,0 +1,38 @@
+package com.instacart.library.truetime;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import static android.content.Context.MODE_PRIVATE;
+
+class SharedPreferenceCacheImpl implements CacheInterface {
+
+    private static final String KEY_CACHED_SHARED_PREFS = "com.instacart.library.truetime.shared_preferences";
+
+    private SharedPreferences _sharedPreferences = null;
+
+    public SharedPreferenceCacheImpl(Context context) {
+        _sharedPreferences = context.getSharedPreferences(KEY_CACHED_SHARED_PREFS, MODE_PRIVATE);
+    }
+
+    @Override
+    public void put(@TrueTimeCacheType String key, long value) {
+        _sharedPreferences.edit().putLong(key, value).apply();
+    }
+
+    @Override
+    public long get(@TrueTimeCacheType String key, long defaultValue) {
+        return _sharedPreferences.getLong(key, defaultValue);
+    }
+
+    @Override
+    public void clear() {
+        remove(CacheInterface.KEY_CACHED_BOOT_TIME);
+        remove(CacheInterface.KEY_CACHED_DEVICE_UPTIME);
+        remove(CacheInterface.KEY_CACHED_SNTP_TIME);
+    }
+
+    private void remove(@TrueTimeCacheType String keyCachedBootTime) {
+        _sharedPreferences.edit().remove(keyCachedBootTime).apply();
+    }
+}

--- a/library/src/main/java/com/instacart/library/truetime/SharedPreferenceCacheImpl.java
+++ b/library/src/main/java/com/instacart/library/truetime/SharedPreferenceCacheImpl.java
@@ -9,19 +9,19 @@ class SharedPreferenceCacheImpl implements CacheInterface {
 
     private static final String KEY_CACHED_SHARED_PREFS = "com.instacart.library.truetime.shared_preferences";
 
-    private SharedPreferences _sharedPreferences = null;
+    private SharedPreferences _sharedPreferences;
 
     public SharedPreferenceCacheImpl(Context context) {
         _sharedPreferences = context.getSharedPreferences(KEY_CACHED_SHARED_PREFS, MODE_PRIVATE);
     }
 
     @Override
-    public void put(@TrueTimeCacheType String key, long value) {
+    public void put(String key, long value) {
         _sharedPreferences.edit().putLong(key, value).apply();
     }
 
     @Override
-    public long get(@TrueTimeCacheType String key, long defaultValue) {
+    public long get(String key, long defaultValue) {
         return _sharedPreferences.getLong(key, defaultValue);
     }
 
@@ -32,7 +32,7 @@ class SharedPreferenceCacheImpl implements CacheInterface {
         remove(CacheInterface.KEY_CACHED_SNTP_TIME);
     }
 
-    private void remove(@TrueTimeCacheType String keyCachedBootTime) {
+    private void remove(String keyCachedBootTime) {
         _sharedPreferences.edit().remove(keyCachedBootTime).apply();
     }
 }

--- a/library/src/main/java/com/instacart/library/truetime/TrueTime.java
+++ b/library/src/main/java/com/instacart/library/truetime/TrueTime.java
@@ -66,9 +66,17 @@ public class TrueTime {
     /**
      * Customized TrueTime Cache implementation.
      */
-    public synchronized TrueTime withCustomizedCacheInterface(CacheInterface cacheInterface) {
+    public synchronized TrueTime withCustomizedCache(CacheInterface cacheInterface) {
         DISK_CACHE_CLIENT.enableCacheInterface(cacheInterface);
         return INSTANCE;
+    }
+
+    /**
+     * Clear the cache cache when the device is rebooted.
+     * @param cacheInterface the customized cache interface to save the true time data.
+     */
+    public static void clearCachedInfo(CacheInterface cacheInterface) {
+        DISK_CACHE_CLIENT.clearCachedInfo(cacheInterface);
     }
 
     public synchronized TrueTime withConnectionTimeout(int timeoutInMillis) {

--- a/library/src/main/java/com/instacart/library/truetime/TrueTime.java
+++ b/library/src/main/java/com/instacart/library/truetime/TrueTime.java
@@ -58,8 +58,16 @@ public class TrueTime {
      * Cache TrueTime initialization information in SharedPreferences
      * This can help avoid additional TrueTime initialization on app kills
      */
-    public synchronized TrueTime withSharedPreferences(Context context) {
-        DISK_CACHE_CLIENT.enableDiskCaching(context);
+    public synchronized TrueTime withSharedPreferencesCache(Context context) {
+        DISK_CACHE_CLIENT.enableSharedPreferenceCaching(context);
+        return INSTANCE;
+    }
+
+    /**
+     * Customized TrueTime Cache implementation.
+     */
+    public synchronized TrueTime withCustomizedCacheInterface(CacheInterface cacheInterface) {
+        DISK_CACHE_CLIENT.enableCacheInterface(cacheInterface);
         return INSTANCE;
     }
 

--- a/library/src/main/java/com/instacart/library/truetime/TrueTime.java
+++ b/library/src/main/java/com/instacart/library/truetime/TrueTime.java
@@ -47,7 +47,6 @@ public class TrueTime {
 
     public void initialize() throws IOException {
         initialize(_ntpHost);
-        saveTrueTimeInfoToDisk();
     }
 
     /**
@@ -127,6 +126,7 @@ public class TrueTime {
         }
 
         requestTime(ntpHost);
+        saveTrueTimeInfoToDisk();
     }
 
     long[] requestTime(String ntpHost) throws IOException {

--- a/library/src/main/java/com/instacart/library/truetime/TrueTime.java
+++ b/library/src/main/java/com/instacart/library/truetime/TrueTime.java
@@ -45,10 +45,6 @@ public class TrueTime {
         return INSTANCE;
     }
 
-    public static void clearCachedInfo(Context context) {
-        DISK_CACHE_CLIENT.clearCachedInfo(context);
-    }
-
     public void initialize() throws IOException {
         initialize(_ntpHost);
         saveTrueTimeInfoToDisk();
@@ -59,7 +55,7 @@ public class TrueTime {
      * This can help avoid additional TrueTime initialization on app kills
      */
     public synchronized TrueTime withSharedPreferencesCache(Context context) {
-        DISK_CACHE_CLIENT.enableSharedPreferenceCaching(context);
+        DISK_CACHE_CLIENT.enableCacheInterface(new SharedPreferenceCacheImpl(context));
         return INSTANCE;
     }
 
@@ -72,11 +68,10 @@ public class TrueTime {
     }
 
     /**
-     * Clear the cache cache when the device is rebooted.
-     * @param cacheInterface the customized cache interface to save the true time data.
+     * clear the cached TrueTime info on device reboot.
      */
-    public static void clearCachedInfo(CacheInterface cacheInterface) {
-        DISK_CACHE_CLIENT.clearCachedInfo(cacheInterface);
+    public static void clearCachedInfo() {
+        DISK_CACHE_CLIENT.clearCachedInfo();
     }
 
     public synchronized TrueTime withConnectionTimeout(int timeoutInMillis) {


### PR DESCRIPTION
Currently, if we would like to cache the true time, we have to use SharedPreference. However, this might be a security loop if we do not encrypt the cache time as the cache time could be modified on rooted time by accessing the application sandbox. So I did some modification and provide an interface for these who would like to manage the cache of TrueTime on their own if it is deemed necessary.