### PR TITLE
Add ipv6 filtering

### DIFF
--- a/app/src/main/java/com/instacart/library/sample/App.java
+++ b/app/src/main/java/com/instacart/library/sample/App.java
@@ -60,6 +60,7 @@ public class App extends Application {
                 .withConnectionTimeout(31_428)
                 .withRetryCount(100)
                 .withSharedPreferencesCache(this)
+                .withoutIpV6()
                 .withLoggingEnabled(true)
                 .initializeRx("time.google.com")
                 .subscribeOn(Schedulers.io())

--- a/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
+++ b/library-extension-rx/src/main/java/com/instacart/library/truetime/TrueTimeRx.java
@@ -13,8 +13,10 @@ import io.reactivex.functions.Function;
 import io.reactivex.functions.Predicate;
 import io.reactivex.schedulers.Schedulers;
 import java.io.IOException;
+import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -29,6 +31,8 @@ public class TrueTimeRx
     private static final String TAG = TrueTimeRx.class.getSimpleName();
 
     private int _retryCount = 50;
+
+    private Predicate<InetAddress> _addressFilter = null;
 
     public static TrueTimeRx build() {
         return RX_INSTANCE;
@@ -45,6 +49,21 @@ public class TrueTimeRx
      */
     public TrueTimeRx withCustomizedCache(CacheInterface cacheInterface) {
         super.withCustomizedCache(cacheInterface);
+        return this;
+    }
+
+    public TrueTimeRx withoutIpV6() {
+        _addressFilter = new Predicate<InetAddress>() {
+            @Override
+            public boolean test(InetAddress inetAddress) {
+                return inetAddress instanceof Inet4Address;
+            }
+        };
+        return this;
+    }
+
+    public TrueTimeRx withCustomIpAddressFilter(Predicate<InetAddress> predicate) {
+        _addressFilter = predicate;
         return this;
     }
 
@@ -180,7 +199,23 @@ public class TrueTimeRx
                           public Flowable<InetAddress> apply(String ntpPoolAddress) {
                               try {
                                   TrueLog.d(TAG, "---- resolving ntpHost : " + ntpPoolAddress);
-                                  return Flowable.fromArray(InetAddress.getAllByName(ntpPoolAddress));
+                                  InetAddress[] addresses = InetAddress.getAllByName(ntpPoolAddress);
+                                  Predicate<InetAddress> filter = _addressFilter;
+                                  if (filter == null) {
+                                      return Flowable.fromArray(addresses);
+                                  } else {
+                                      ArrayList<InetAddress> validAddresses = new ArrayList<>();
+                                      for (InetAddress i : addresses) {
+                                          try {
+                                              if (filter.test(i)) {
+                                                  validAddresses.add(i);
+                                              }
+                                          } catch (Exception e) {
+                                              return Flowable.error(e);
+                                          }
+                                      }
+                                      return Flowable.fromIterable(validAddresses);
+                                  }
                               } catch (UnknownHostException e) {
                                   return Flowable.error(e);
                               }


### PR DESCRIPTION
The ipv6 addresses that time.google.com resolve to give repeated SocketTimeoutExceptions. This allows these to be filtered out if desired.