### PR TITLE
Introduced the ability to listen for the correct completion of each request.

### DIFF
--- a/app/src/main/java/com/instacart/library/sample/App.java
+++ b/app/src/main/java/com/instacart/library/sample/App.java
@@ -11,12 +11,21 @@ import java.io.IOException;
 import java.util.Date;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.functions.Consumer;
 import io.reactivex.observers.DisposableSingleObserver;
 import io.reactivex.schedulers.Schedulers;
 
 public class App extends Application {
 
     private static final String TAG = App.class.getSimpleName();
+
+    private int successResponseCounter = 0;
+    private Consumer<long[]> successResponseListener = new Consumer<long[]>() {
+        @Override
+        public void accept(long[] longs) throws Exception {
+            successResponseCounter++;
+        }
+    };
 
     @Override
     public void onCreate() {
@@ -61,6 +70,7 @@ public class App extends Application {
                 .withRetryCount(100)
                 .withSharedPreferencesCache(this)
                 .withLoggingEnabled(true)
+                .withSuccessResponseListener(successResponseListener)
                 .initializeRx("time.google.com")
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
@@ -77,5 +87,7 @@ public class App extends Application {
                 });
     }
 
-
+    public int getSuccessResponseCounter() {
+        return successResponseCounter;
+    }
 }

--- a/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
+++ b/app/src/main/java/com/instacart/library/sample/Sample2Activity.java
@@ -26,6 +26,7 @@ public class Sample2Activity
     @BindView(R.id.tt_time_gmt) TextView timeGMT;
     @BindView(R.id.tt_time_pst) TextView timePST;
     @BindView(R.id.tt_time_device) TextView timeDeviceTime;
+    @BindView(R.id.tt_success_response_counter) TextView successResponses;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -35,6 +36,8 @@ public class Sample2Activity
         getSupportActionBar().setTitle("TrueTimeRx");
 
         ButterKnife.bind(this);
+        successResponses.setText(getString(R.string.tt_success_response_counter,
+                                           ((App) getApplication()).getSuccessResponseCounter()));
         refreshBtn.setEnabled(TrueTimeRx.isInitialized());
     }
 

--- a/app/src/main/res/layout/activity_sample.xml
+++ b/app/src/main/res/layout/activity_sample.xml
@@ -9,6 +9,24 @@
     tools:context="com.instacart.library.sample.SampleActivity">
 
     <TextView
+        android:id="@+id/tt_success_response_counter"
+
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+
+        android:text="Success response counter goes here"
+        android:textSize="20dp"
+
+        app:layout_constraintBottom_toTopOf="@+id/tt_time_device"
+        app:layout_constraintHorizontal_bias="0.47"
+        app:layout_constraintLeft_toLeftOf="@+id/activity_main"
+        app:layout_constraintRight_toRightOf="@+id/activity_main"
+        tools:layout_constraintBottom_creator="1"
+        tools:layout_constraintLeft_creator="1"
+        tools:layout_constraintRight_creator="1"/>
+
+    <TextView
         android:id="@+id/tt_time_pst"
 
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">TrueTime (Sample) for Android</string>
+    <string name="tt_success_response_counter">%1$d successful response during last init</string>
     <string name="tt_time_gmt">TrueTime: %1$s [GMT]</string>
     <string name="tt_time_pst">TrueTime: %1$s [PST]</string>
     <string name="tt_time_device">Device Time: %1$s [PST]</string>


### PR DESCRIPTION
I've encountered similar issue to the one described in issue #109  . Thought that will be cool to be able to observe successful response per request not as whole initialization. It's because as explained in mentioned issue init will fail if even single request fail but actually `now()` will return time even if only one request succeeded. So here is my proposed solution. It'll allow to know if at least one request during synchronization succeeded or will allow the user of the library want he/she could implement some sort of `threshold of successful requests` like author of issue #109  suggested.