### PR TITLE
Fix: Vulnerable exported broadcast receiver

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
 
     <application>
         <!-- Start the Service if applicable on boot -->
-        <receiver android:name=".BootCompletedBroadcastReceiver">
+        <receiver android:name=".BootCompletedBroadcastReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
             </intent-filter>


### PR DESCRIPTION
This Receiver can use by other applications. but does not properly restrict which applications can launch the component or access the data it contains. Making it non-exportable for fixing the vulnerability 