### PR TITLE
adding android sdk 31 support

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
 
     <application>
         <!-- Start the Service if applicable on boot -->
-        <receiver android:name=".BootCompletedBroadcastReceiver">
+        <receiver android:name=".BootCompletedBroadcastReceiver"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
             </intent-filter>


### PR DESCRIPTION
for supporting android sdk 31, 
manifest merge will fail there is no explicit export attribute is not set. 
---- Error -----
Manifest merger failed : android:exported needs to be explicitly specified for <receiver>. Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.