### PR TITLE
Migrate to Instant from Date

### DIFF
--- a/app/src/main/java/com/instacart/sample/SampleActivity.kt
+++ b/app/src/main/java/com/instacart/sample/SampleActivity.kt
@@ -15,12 +15,12 @@ import com.instacart.truetime.time.TrueTimeParameters
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.*
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.*
 import kotlin.concurrent.schedule
-import kotlinx.coroutines.*
 
 @SuppressLint("SetTextI18n")
 @RequiresApi(Build.VERSION_CODES.O)
@@ -55,7 +55,7 @@ class SampleActivity : AppCompatActivity() {
     kickOffTruetimeCoroutines()
     kickOffTrueTimeRx()
 
-    binding.deviceTime.text = "Device Time: ${formatDate(Date())}"
+    binding.deviceTime.text = "Device Time: ${formatInstant(Instant.now())}"
   }
 
   private fun kickOffTruetimeCoroutines() {
@@ -85,7 +85,7 @@ class SampleActivity : AppCompatActivity() {
         delay(500)
       }
 
-      binding.truetimeNew.text = "(Coroutines): ${formatDate(sampleTrueTime.now())}"
+      binding.truetimeNew.text = "(Coroutines): ${formatInstant(sampleTrueTime.now())}"
     }
 
     if (false) {
@@ -106,14 +106,15 @@ class SampleActivity : AppCompatActivity() {
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(
-                { date -> binding.truetimeLegacy.text = "(Rx) : ${formatDate(date)}" },
-                { Log.e("Demo", "something went wrong when trying to initializeRx TrueTime", it) })
+                { date -> binding.truetimeLegacy.text = "(Rx) : ${formatInstant(date.toInstant())}" },
+                { Log.e("Demo", "something went wrong when trying to initializeRx TrueTime", it) },
+            )
 
     disposables.add(d)
   }
 
-  private fun formatDate(date: Date): String {
-    return Instant.ofEpochMilli(date.time)
+  private fun formatInstant(instant: Instant): String {
+    return instant
         .atZone(ZoneId.of("America/Los_Angeles"))
         .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
   }

--- a/app/src/main/java/com/instacart/sample/TrueTimeLogEventListener.kt
+++ b/app/src/main/java/com/instacart/sample/TrueTimeLogEventListener.kt
@@ -5,7 +5,7 @@ import com.instacart.truetime.TrueTimeEventListener
 import com.instacart.truetime.sntp.SntpResult
 import com.instacart.truetime.time.TrueTimeParameters
 import java.net.InetAddress
-import java.util.*
+import java.time.Instant
 
 class TrueTimeLogEventListener : TrueTimeEventListener {
   override fun initialize(params: TrueTimeParameters) {
@@ -57,7 +57,7 @@ class TrueTimeLogEventListener : TrueTimeEventListener {
     Log.v("TrueTime4 TimeKeeper", "TimeKeeper storing time $ntpResult")
   }
 
-  override fun returningTrueTime(trueTime: Date) {
+  override fun returningTrueTime(trueTime: Instant) {
     Log.v("TrueTime4 TimeKeeper", "returning TrueTime $trueTime")
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     ext {
         kotlin_version = '1.8.0'
         coroutines_version = '1.6.4'
+        desugar_version = '2.0.2'
     }
 
     repositories {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,6 +15,7 @@ android {
         aarMetadata {
             minCompileSdk = rootProject.ext.compileSdkVersion
         }
+        multiDexEnabled true
     }
 
     buildTypes {
@@ -29,6 +30,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
@@ -39,6 +41,7 @@ android {
 
 dependencies {
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$desugar_version"
 }
 
 afterEvaluate {

--- a/library/src/main/java/com/instacart/truetime/TrueTimeEventListener.kt
+++ b/library/src/main/java/com/instacart/truetime/TrueTimeEventListener.kt
@@ -3,7 +3,7 @@ package com.instacart.truetime
 import com.instacart.truetime.sntp.SntpResult
 import com.instacart.truetime.time.TrueTimeParameters
 import java.net.InetAddress
-import java.util.*
+import java.time.Instant
 
 interface TrueTimeEventListener : SntpEventListener, TimeKeeperListener {
   /** [com.instacart.truetime.time.TrueTime] initialize call performed */
@@ -42,7 +42,7 @@ interface TimeKeeperListener {
   fun storingTrueTime(ntpResult: SntpResult)
 
   /** TimeKeeper has the "true" time and is returning it */
-  fun returningTrueTime(trueTime: Date)
+  fun returningTrueTime(trueTime: Instant)
 
   /** TimeKeeper does not have the "true" time returning device time. */
   fun returningDeviceTime()
@@ -63,6 +63,6 @@ object NoOpEventListener : TrueTimeEventListener {
   override fun sntpRequestFailed(address: InetAddress, e: Exception) {}
 
   override fun storingTrueTime(ntpResult: SntpResult) {}
-  override fun returningTrueTime(trueTime: Date) {}
+  override fun returningTrueTime(trueTime: Instant) {}
   override fun returningDeviceTime() {}
 }

--- a/library/src/main/java/com/instacart/truetime/time/TimeKeeper.kt
+++ b/library/src/main/java/com/instacart/truetime/time/TimeKeeper.kt
@@ -4,7 +4,7 @@ import android.os.SystemClock
 import com.instacart.truetime.CacheProvider
 import com.instacart.truetime.TimeKeeperListener
 import com.instacart.truetime.sntp.SntpResult
-import java.util.*
+import java.time.Instant
 
 // TODO: move android dependency to separate package
 //  so we can make Truetime a pure kotlin library
@@ -22,27 +22,27 @@ internal class TimeKeeper(
 
   fun hasTheTime(): Boolean = cacheProvider.hasInfo()
 
-  fun nowSafely(): Date {
+  fun nowSafely(): Instant {
     return if (hasTheTime()) {
       nowTrueOnly()
     } else {
       listener.returningDeviceTime()
-      Date()
+      Instant.now()
     }
   }
 
-  fun nowTrueOnly(): Date {
+  fun nowTrueOnly(): Instant {
     if (!hasTheTime()) throw IllegalStateException("TrueTime was not initialized successfully yet")
     return now()
   }
 
   /** Given the available information provide the best known time */
-  private fun now(): Date {
+  private fun now(): Instant {
     val ntpResult = cacheProvider.fetch()!!
     val savedSntpTime: Long = ntpResult.trueTime()
     val timeSinceBoot: Long = ntpResult.timeSinceBoot()
     val currentTimeSinceBoot: Long = SystemClock.elapsedRealtime()
-    val trueTime = Date(savedSntpTime + (currentTimeSinceBoot - timeSinceBoot))
+    val trueTime = Instant.ofEpochMilli(savedSntpTime + (currentTimeSinceBoot - timeSinceBoot))
     listener.returningTrueTime(trueTime)
     return trueTime
   }

--- a/library/src/main/java/com/instacart/truetime/time/TrueTime.kt
+++ b/library/src/main/java/com/instacart/truetime/time/TrueTime.kt
@@ -1,7 +1,8 @@
 package com.instacart.truetime.time
 
-import java.util.*
 import kotlinx.coroutines.Job
+import java.time.Instant
+import java.util.*
 
 /** This is the main class that has the APIs for accessing Truetime. */
 interface TrueTime {
@@ -18,16 +19,16 @@ interface TrueTime {
    * This is [TrueTime]'s main function to get time It should respect
    * [TrueTimeParameters.returnSafelyWhenUninitialized] setting
    */
-  fun now(): Date
+  fun now(): Instant
 
   /**
    * return the current time as calculated by TrueTime. If TrueTime doesn't [hasTheTime], will throw
    * [IllegalStateException]
    */
-  @Throws(IllegalStateException::class) fun nowTrueOnly(): Date
+  @Throws(IllegalStateException::class) fun nowTrueOnly(): Instant
 
   /** return [nowTrueOnly] if TrueTime is available otherwise fallback to System clock date */
-  fun nowSafely(): Date
+  fun nowSafely(): Instant
 
   /** Does [TrueTime] have the "true" time or about to default to device time */
   fun hasTheTime(): Boolean


### PR DESCRIPTION
This supports recent major overhaul of code by replacing legacy `Date` with [modern date and time API](https://www.oracle.com/technical-resources/articles/java/jf14-date-time.html) (`Instant` in this case).  Older Android versions are supported with help of [Java 8 desugaring](https://developer.android.com/studio/write/java8-support).