### PR TITLE
fix|reboot detection via boot_id + bump to 4.0.1.alpha

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@ compileSdk = "33"
 minSdk = "21"
 targetSdk = "33"
 
-trueTimeVersionCode = "12"
-trueTime = "4.0.0.alpha"
+trueTimeVersionCode = "13"
+trueTime = "4.0.1.alpha"
 trueTimeRx = "3.5"
 
 androidGradlePlugin = "8.0.2"

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -17,7 +17,12 @@ android {
     aarMetadata { minCompileSdk = libs.versions.compileSdk.get().toInt() }
   }
 
-  buildTypes { getByName("release") { isMinifyEnabled = false } }
+  buildTypes {
+    getByName("release") {
+      isMinifyEnabled = false
+      consumerProguardFiles("consumer-rules.pro")
+    }
+  }
 
   buildFeatures { buildConfig = false }
 

--- a/library/consumer-rules.pro
+++ b/library/consumer-rules.pro
@@ -1,0 +1,9 @@
+# Keep TrueTime public API
+-keep public class com.instacart.truetime.time.TrueTime { *; }
+-keep public class com.instacart.truetime.time.TrueTimeImpl { *; }
+-keep public class com.instacart.truetime.time.TrueTimeParameters { *; }
+-keep public class com.instacart.truetime.time.TrueTimeParameters$Builder { *; }
+-keep public interface com.instacart.truetime.CacheProvider { *; }
+-keep public class com.instacart.truetime.BasicCacheProvider { *; }
+-keep public interface com.instacart.truetime.TrueTimeEventListener { *; }
+-keep public class com.instacart.truetime.sntp.SntpResult { *; }

--- a/library/consumer-rules.pro
+++ b/library/consumer-rules.pro
@@ -1,5 +1,5 @@
 # Keep TrueTime public API
--keep public class com.instacart.truetime.time.TrueTime { *; }
+-keep public interface com.instacart.truetime.time.TrueTime { *; }
 -keep public class com.instacart.truetime.time.TrueTimeImpl { *; }
 -keep public class com.instacart.truetime.time.TrueTimeParameters { *; }
 -keep public class com.instacart.truetime.time.TrueTimeParameters$Builder { *; }

--- a/library/src/main/java/com/instacart/truetime/sntp/SntpImpl.java
+++ b/library/src/main/java/com/instacart/truetime/sntp/SntpImpl.java
@@ -24,6 +24,8 @@ import com.instacart.truetime.SntpEventListener;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
@@ -187,7 +189,7 @@ public class SntpImpl implements Sntp {
 
             listener.sntpRequestSuccessful(address);
 
-            return new SntpResult(t);
+            return new SntpResult(t, readBootId());
 
         } catch (Exception e) {
             listener.sntpRequestFailed(address, e);
@@ -200,6 +202,20 @@ public class SntpImpl implements Sntp {
     }
 
     //region private helpers
+
+    /**
+     * Reads the kernel boot ID from /proc/sys/kernel/random/boot_id.
+     * This UUID changes on every device reboot, making it a reliable reboot detector.
+     * Returns an empty string if the file cannot be read.
+     */
+    private String readBootId() {
+        try (BufferedReader reader = new BufferedReader(new FileReader("/proc/sys/kernel/random/boot_id"))) {
+            String line = reader.readLine();
+            return line != null ? line.trim() : "";
+        } catch (Exception e) {
+            return "";
+        }
+    }
 
     /**
      * Writes NTP version as defined in RFC-1305

--- a/library/src/main/java/com/instacart/truetime/sntp/SntpResult.kt
+++ b/library/src/main/java/com/instacart/truetime/sntp/SntpResult.kt
@@ -2,6 +2,9 @@ package com.instacart.truetime.sntp
 
 class SntpResult(val ntpResult: LongArray, val bootId: String = "") {
 
+  // Secondary constructor for Java binary compatibility (preserves original JVM signature)
+  constructor(ntpResult: LongArray) : this(ntpResult, "")
+
   /** See δ : https://en.wikipedia.org/wiki/Network_Time_Protocol#Clock_synchronization_algorithm */
   fun roundTripDelay(): Long {
     return ntpResult[SntpImpl.RESPONSE_INDEX_RESPONSE_TIME] -

--- a/library/src/main/java/com/instacart/truetime/sntp/SntpResult.kt
+++ b/library/src/main/java/com/instacart/truetime/sntp/SntpResult.kt
@@ -1,6 +1,6 @@
 package com.instacart.truetime.sntp
 
-class SntpResult(val ntpResult: LongArray) {
+class SntpResult(val ntpResult: LongArray, val bootId: String = "") {
 
   /** See δ : https://en.wikipedia.org/wiki/Network_Time_Protocol#Clock_synchronization_algorithm */
   fun roundTripDelay(): Long {

--- a/library/src/main/java/com/instacart/truetime/time/TimeKeeper.kt
+++ b/library/src/main/java/com/instacart/truetime/time/TimeKeeper.kt
@@ -4,6 +4,7 @@ import android.os.SystemClock
 import com.instacart.truetime.CacheProvider
 import com.instacart.truetime.TimeKeeperListener
 import com.instacart.truetime.sntp.SntpResult
+import java.io.File
 import java.util.*
 
 // TODO: move android dependency to separate package
@@ -24,14 +25,30 @@ internal class TimeKeeper(
     if (!cacheProvider.hasAnyEntries()) return false
 
     val lastEntry = cacheProvider.fetchLatest()!!
-    val currentElapsedTime = SystemClock.elapsedRealtime()
-    val deviceRebooted = lastEntry.timeSinceBoot() > currentElapsedTime
+    val deviceRebooted =
+        if (lastEntry.bootId.isNotEmpty()) {
+          // Reliable: boot ID changes on every reboot regardless of uptime
+          lastEntry.bootId != currentBootId()
+        } else {
+          // Fallback for cached entries without a boot ID: elapsed time heuristic.
+          // This can miss reboots once uptime exceeds the saved timeSinceBoot value.
+          lastEntry.timeSinceBoot() > SystemClock.elapsedRealtime()
+        }
+
     if (deviceRebooted) {
       cacheProvider.invalidate()
       listener.invalidateCacheOnRebootDetection()
     }
 
     return !deviceRebooted
+  }
+
+  private fun currentBootId(): String {
+    return try {
+      File("/proc/sys/kernel/random/boot_id").readText().trim()
+    } catch (e: Exception) {
+      ""
+    }
   }
 
   fun nowSafely(): Date {


### PR DESCRIPTION
Replace elapsed-time heuristic with /proc/sys/kernel/random/boot_id comparison in TimeKeeper. SntpResult now carries the boot ID captured at sync time; TimeKeeper compares it on cache validation to reliably detect reboots regardless of uptime. Falls back to old elapsed-time check for cached entries that predate this change.

Also add consumer-rules.pro to keep the public TrueTime API under ProGuard/R8, and wire it into the release build type.